### PR TITLE
Translate classes that contain only `enum`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,43 @@ You'll get output that looks something like this:
 
 ```bash
 [bash][atlas AnalysisBase-21.2.184]:func-adl-types-atlas > ./scripts/run_on_atlas_containers.sh > test1.txt 
-ERROR: Cannot translate class 'xAOD::CompositeParticleContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::CompositeParticleAuxContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::IParticleLinkContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::ParticleAuxContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::ParticleContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::egammaRecContainer': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'xAOD::CMXJetHitsAuxContainer': ROOT's type system doesn't have it loaded.
+[bash][atlas AnalysisBase-21.2.247]:func-adl-types-atlas > 
+[bash][atlas AnalysisBase-21.2.247]:func-adl-types-atlas > ./scripts/run_on_atlas_containers.sh > test1.yaml
+ERROR: Cannot translate class 'xAOD::CaloRingsAuxContainer': ROOT's type system doesn't have it loaded as a class.
+ERROR: Cannot translate class 'xAOD::RingSetAuxContainer': ROOT's type system doesn't have it loaded as a class.
+ERROR: Cannot translate class 'xAOD::CaloRingsContainer': ROOT's type system doesn't have it loaded as a class.
+ERROR: Cannot translate class 'xAOD::RingSetConfAuxContainer': ROOT's type system doesn't have it loaded as a class.
+ERROR: Cannot translate class 'xAOD::RingSetConfContainer': ROOT's type system doesn't have it loaded as a class.
 ...
-INFO: Not translating '__shared_ptr<ROOT::Math::Minimizer, __gnu_cxx::_Lock_policy::_S_atomic>' as it is a private internal class (__shared_ptr)
-INFO: Not translating '__shared_ptr<ROOT::Math::Minimizer>' as it is a private internal class (__shared_ptr)
-INFO: Not translating '__shared_ptr_access<ROOT::Math::Minimizer, __gnu_cxx::_Lock_policy::_S_atomic, false, false>' as it is a private internal class (__shared_ptr_access)
-ERROR: Cannot translate class 'Axis_t': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'Bool_t()(const TGraph,Int_t,Int_t)': ROOT's type system doesn't have it loaded.
-ERROR: Cannot translate class 'mutex::native_handle_type': ROOT's type system doesn't have it loaded.
+ERROR: Class DataModel_detail::DVLIteratorBase not translated: no methods to emit.
+ERROR: Class ROOT::Experimental::Internal::TBulkBranchRead not translated: no methods to emit.
+ERROR: Class ROOT::TIOFeatures not translated: no methods to emit.
+ERROR: Class TPoint not translated: no methods to emit.
+ERROR: Class TRefCnt not translated: no methods to emit.
+ERROR: Class TTree::TClusterIterator not translated: no methods to emit.
+ERROR: Class TVirtualIsAProxy not translated: no methods to emit.
+ERROR: Class condition_variable not translated: no methods to emit.
+ERROR: Class vector<TStreamerInfoActions::TIDNode> not translated: template arguments were bad.
+ERROR: Class vector<const ROOT::TSchemaRule *> not translated: template arguments were bad.
+ERROR: Class vector<const double *> not translated: template arguments were bad.
+ERROR: Class vector<const xAOD::CaloCluster_v1 *> not translated: template arguments were bad.
+ERROR: Class vector<const xAOD::IParticle *> not translated: template arguments were bad.
+...
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::GetClassName - some types not emitted: TString, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::GetRules - some types not emitted: TObjArray, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::GetPersistentRules - some types not emitted: TObjArray, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Class_Version - some types not emitted: Version_t, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::IsA - some types not emitted: TClass, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::DeclFileName - some types not emitted: char, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::ImplFileName - some types not emitted: char, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Class_Name - some types not emitted: char, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Dictionary - some types not emitted: TClass, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Class - some types not emitted: TClass, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Hash - some types not emitted: ULong_t, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::ClassName - some types not emitted: char, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::CheckedHash - some types not emitted: ULong_t, 
+ERROR: Cannot emit method ROOT::Detail::TSchemaRuleSet::Clone - some types not emitted: TObject, char, 
+...
 ```
 
 And you will have a giant `yaml` file containing the complete type system. That `yaml` file can be read by the type generator system.

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -614,12 +614,16 @@ int main(int argc, char**argv) {
                 out << YAML::EndMap;
             } else {
                 auto method_args(referenced_types(meth));
-                cerr << "ERROR: Cannot emit method " << c_info->first << "::" << meth.name << " - some types not emitted: ";
-                for (const auto& arg : method_args) {
-                    cerr << arg << ", ";
+                // Do not warn when return type is void - this is just how we work
+                // in a functional world for now (e.g. by design).
+                if (meth.return_type.size() != 0) {
+                    cerr << "ERROR: Cannot emit method " << c_info->first << "::" << meth.name << " - some types not emitted: ";
+                    for (const auto& arg : method_args) {
+                        cerr << arg << ", ";
+                    }
+                    cerr << endl;
                 }
-                cerr << endl;
-                        }
+            }
         }
 
         if (!first_method) {

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -283,6 +283,17 @@ int main(int argc, char**argv) {
                     classes_to_do.push(c_name);
                 }
             }        
+        } else {
+            // The class might actually be an enum, and the parent might
+            // be something we can translate. So - parse off one level down in the
+            // type name, and add it to the list, and see what happens.
+            auto t = parse_typename(class_name);
+            if (t.namespace_list.size() > 0) {
+                auto parent_class_name = unqualified_typename(parent_class(t));
+                if (class_name_is_good(parent_class_name)) {
+                    classes_to_do.push(parent_class_name);
+                }
+            }
         }
     }
 

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -248,6 +248,8 @@ int main(int argc, char**argv) {
     vector<class_info> done_classes;
 
     while (classes_to_do.size() > 0) {
+        // Grab a class and mark it on the list
+        // so we don't try to re-run it.
         auto raw_class_name(classes_to_do.front());
         classes_to_do.pop();
         if (classes_done.find(raw_class_name) != classes_done.end())
@@ -261,10 +263,20 @@ int main(int argc, char**argv) {
             }
         classes_done.insert(class_name);
 
+        // Translate the class
         auto c = translate_class(class_name);
+
+        // If we translated it, look at all classes it referenced and
+        // add them to the list to translate.
         if (c.name.size() > 0) {
+            // Mark this class done
             done_classes.push_back(c);
 
+            // Add enum's to the `classes_done` list so we don't try to translate them again.
+            auto defined_enums = class_enums(c);
+            classes_done.insert(defined_enums.begin(), defined_enums.end());
+
+            // Add any referenced classes to our class list!
             for (auto &&c_name : referenced_types(c))
             {
                 if (class_name_is_good(c_name)) {

--- a/include/type_helpers.hpp
+++ b/include/type_helpers.hpp
@@ -34,6 +34,10 @@ std::string unqualified_type_name(const std::string &full_type_name);
 // Parse a fully qualified C++ typename
 typename_info parse_typename(const std::string &type_name);
 
+// Pop a parent class (std::org::size -> std:org).
+//  - throw exception if there are no parent classes.
+typename_info parent_class(const typename_info &ti);
+
 // Return type info for the first class or inherited class that
 // has name as the name of a template class.
 typename_info get_first_class(const class_info &c, const std::string &name);

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -209,7 +209,7 @@ class_info translate_class(const std::string &class_name)
     auto c_info = TClass::GetClass(unq_class_name.c_str());
     if (c_info == nullptr)
     {
-        std::cerr << "ERROR: Cannot translate class '" << class_name << "': ROOT's type system doesn't have it loaded." << std::endl;
+        std::cerr << "ERROR: Cannot translate class '" << class_name << "': ROOT's type system doesn't have it loaded as a class." << std::endl;
         return result;
     }
     // There are several other types of classes we do not need to translate as well.

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -630,3 +630,28 @@ vector<string> class_enums(const class_info &c)
 
     return result;
 }
+
+// Determine the parent class our surrounding
+// namespace.
+typename_info parent_class(const typename_info &ti)
+{
+    // Make sure this is going to work!
+    if (ti.namespace_list.size() == 0) {
+        throw invalid_argument("No parent class for " + ti.nickname);
+    }
+
+    // Pop ourselves one up!
+    typename_info result = ti.namespace_list.back();
+
+    // Re-insert all the extra namespace info.
+    result.namespace_list.insert(result.namespace_list.begin(), ti.namespace_list.begin(), ti.namespace_list.end() - 1);
+
+    // Reset pointer and const-ness
+    result.is_pointer = false;
+    result.is_const = false;
+
+    // And update the nickname
+    result.nickname = typename_cpp_string(result);
+
+    return result;
+}

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -544,7 +544,9 @@ bool is_understood_type(const typename_info &t, const set<std::string> &known_ty
     return false;
 }
 
-// Are all types attached to this class known - is it safe to work with this method?
+// Can we emit this class?
+//  1. The method must return something (e.g. it can't be void)
+//  2. All types used in the method must be known.
 bool is_understood_method(const method_info &meth, const set<string> &classes_to_emit) {
     // Make sure returns something.
     if (meth.return_type.size() == 0) {

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -543,3 +543,53 @@ TEST(t_type_helpers, class_enums_zero) {
 
     EXPECT_EQ(r.size(), 0);
 }
+
+
+TEST(t_type_helpers, parent_class_three) {
+    auto t = parse_typename("std::org::size_t");
+    auto p = parent_class(t);
+
+    EXPECT_EQ(p.type_name, "org");
+    EXPECT_EQ(p.namespace_list.size(), 1);
+    EXPECT_EQ(p.namespace_list[0].type_name, "std");
+    EXPECT_EQ(p.template_arguments.size(), 0);
+    EXPECT_EQ(p.is_const, false);
+    EXPECT_EQ(p.is_pointer, false);
+    EXPECT_EQ(p.nickname, "std::org");
+}
+
+TEST(t_type_helpers, parent_class_const_ptr) {
+    auto t = parse_typename("const std::org::size_t *");
+    auto p = parent_class(t);
+
+    EXPECT_EQ(p.type_name, "org");
+    EXPECT_EQ(p.namespace_list.size(), 1);
+    EXPECT_EQ(p.namespace_list[0].type_name, "std");
+    EXPECT_EQ(p.nickname, "std::org");
+    EXPECT_EQ(p.template_arguments.size(), 0);
+    EXPECT_EQ(p.is_const, false);
+    EXPECT_EQ(p.is_pointer, false);
+}
+
+TEST(t_type_helpers, parent_class_none) {
+    auto t = parse_typename("size_t");
+    try {
+        parent_class(t);
+        FAIL() << "Expected std::invalid_argument";
+    } catch (std::invalid_argument const & err) {
+        EXPECT_EQ(err.what(), std::string("No parent class for size_t"));
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument";
+    }   
+}
+
+TEST(t_type_helpers, parent_class_vector) {
+    auto t = parse_typename("std::vector<int>::size_t");
+    auto p = parent_class(t);
+    auto expected = parse_typename("std::vector<int>");
+
+    EXPECT_EQ(p.type_name, expected.type_name);
+    EXPECT_EQ(p.namespace_list.size(), expected.namespace_list.size());
+    EXPECT_EQ(p.nickname, expected.nickname);
+    EXPECT_EQ(p.template_arguments.size(), expected.template_arguments.size());
+}


### PR DESCRIPTION
* If an enum is referenced, make sure the class containing the enum is emitted.

## Minor Updates

* Error messages that reflex accuracy better.
* If a method's return type is void, do not emit an error message about not translating it.

## Other Things To Do:

* [x] Update the readme with error messages new form.

Classes only referenced by enum are not considered for translation 
Fixes #12