### PR TITLE
Class Typesdef's

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ There are lots! However, the log file from running this script will tell you eve
 That said, some classes of things are missing:
 
 * template classes require a lot of extra work, and often custom work. The basics are implemented, but if you find something missing that is required, then please open an issue!
-* class `typedef`'s are not supported and must be hand-coded. This is due to a limitation in ROOT: they do not store this information in a place easily accessible.
+* C++ `class typedef`'s are not supported and must be hand-coded. This is due to a limitation in ROOT: they do not store this information in a place easily accessible.
+* Not every class is translated. Only classes referenced by the ATLAS collections, and anything they in turn reference (and so on) are translated.
 
 ## Supported Releases
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ And you will have a giant `yaml` file containing the complete type system. That 
 
 The above instructions and the Usage instructions should be enough to get you developing on platforms other than windows, with or without `vscode`. PR's welcome to add instructions on how to run on other OS's and development environments!
 
+## Limitations
+
+There are lots! However, the log file from running this script will tell you everything that wasn't translated and a top-level reason as to why not.
+
+That said, some classes of things are missing:
+
+* template classes require a lot of extra work, and often custom work. The basics are implemented, but if you find something missing that is required, then please open an issue!
+* class `typedef`'s are not supported and must be hand-coded. This is due to a limitation in ROOT: they do not store this information in a place easily accessible.
+
 ## Supported Releases
 
 * ATLAS AnalysisBase Containers

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -115,6 +115,10 @@ void build_typedef_map() {
     // Add a few special ones to keep the system working
     g_typedef_map["ULong64_t"] = "unsigned long long";
     g_typedef_map["uint32_t"] = "unsigned int";
+
+    // Some class typedef's that ROOT RTTI can't seem to "get".
+    g_typedef_map["xAOD::CaloCluster_v1::CaloSample"] = "CaloSampling::CaloSample";
+    g_typedef_map["xAOD::CaloCluster_v1::flt_t"] = "float";
 }
 
 // From typedefs, return resolved typedefs.


### PR DESCRIPTION
It would be very niec to automate this process - and extract the class `typedef`'s from ROOT's RTTI. However, that does not look possible. So we will have to implement things as we need them.

* Hard code the `flt_t` float type (`float`).
* Hard code the `CaloSample` enum type (`CaloSampling:CaloCample`).

This is part of what is needed to fix #6

Fixes #10