### PR TITLE
Allow addition of specific types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -165,6 +165,5 @@
         "Wbox",
         "Yvector"
     ],
-    "restructuredtext.preview.docutils.disabled": true,
-    "terminal.integrated.scrollback": 10000
+    "restructuredtext.preview.docutils.disabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -165,5 +165,6 @@
         "Wbox",
         "Yvector"
     ],
-    "restructuredtext.preview.docutils.disabled": true
+    "restructuredtext.preview.docutils.disabled": true,
+    "terminal.integrated.scrollback": 10000
 }

--- a/include/type_helpers.hpp
+++ b/include/type_helpers.hpp
@@ -63,6 +63,9 @@ typename_info container_of(const typename_info &ti);
 bool is_collection(const class_info &ci);
 typename_info container_of(const class_info &ci);
 
+// Return list of referenced types
+std::set<std::string> type_referenced_types(const typename_info &t);
+
 // Is this type something we can deal with?
 bool is_understood_type(const std::string &t_name, const std::set<std::string> &known_types);
 bool is_understood_type(const typename_info &t, const std::set<std::string> &known_types);

--- a/scripts/required_classes.txt
+++ b/scripts/required_classes.txt
@@ -1,0 +1,1 @@
+std::vector<ElementLink<xAOD::MuonContainer>>

--- a/scripts/run_on_atlas_containers.sh
+++ b/scripts/run_on_atlas_containers.sh
@@ -1,5 +1,5 @@
 containers=$(find -L $ROOTCOREDIR/include -name \*Container.h -exec basename {} \; | sed 's/..$//' | sed 's/^/-c xAOD::/')
 libraries=$(find -L $ROOTCOREDIR/lib -name \*.so -exec basename {} \; | grep -vi Dict | grep xAOD | sed 's/...$//' | sed 's/^/-l /')
-required_classes=$(sed 's/^/-c "/; s/$/"/' scripts/required_classes.txt | tr '\n' ' ')
+required_classes=$(sed 's/^/--c "/; s/$/"/' scripts/required_classes.txt | tr '\n' ' ')
 
-./build/generate_types $containers $libraries
+eval ./build/generate_types $containers $libraries $required_classes

--- a/scripts/run_on_atlas_containers.sh
+++ b/scripts/run_on_atlas_containers.sh
@@ -1,4 +1,5 @@
 containers=$(find -L $ROOTCOREDIR/include -name \*Container.h -exec basename {} \; | sed 's/..$//' | sed 's/^/-c xAOD::/')
 libraries=$(find -L $ROOTCOREDIR/lib -name \*.so -exec basename {} \; | grep -vi Dict | grep xAOD | sed 's/...$//' | sed 's/^/-l /')
+required_classes=$(sed 's/^/-c "/; s/$/"/' scripts/required_classes.txt | tr '\n' ' ')
 
 ./build/generate_types $containers $libraries

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -203,6 +203,8 @@ void fixup_type_defs(vector<class_info> &classes)
     }
 }
 
+std::regex _multi_space_regex("\\s+");
+
 // Parse a horrendous C++ typename into its various pieces.
 //
 // "int"
@@ -213,8 +215,7 @@ typename_info parse_typename(const string &type_name)
     typename_info result;
     result.is_const = false;
     result.is_pointer = false;
-    std::regex multi_space_regex("\\s+");
-    result.nickname = trim(regex_replace(type_name, multi_space_regex, " "));
+    result.nickname = trim(regex_replace(type_name, _multi_space_regex, " "));
     bool top_level_is_const = false;
 
     // Simple bail if this is a blank.

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -176,7 +176,7 @@ void fixup_type_aliases(vector<class_info> &classes)
     // Build a typedef backwards mapping
     map<string, vector<string>> typedef_back_map = root_typedef_map();
 
-    // Loop through all the classes we are looking at to see if there is an alias we should be done.
+    // Loop through all the classes we are looking at to see if there is an alias.
     for (auto &&c : classes)
     {
         if (typedef_back_map.find(c.name) != typedef_back_map.end()) {
@@ -188,7 +188,7 @@ void fixup_type_aliases(vector<class_info> &classes)
 // Find referenced arguments in methods and resolve any typedefs in there
 void fixup_type_defs(vector<class_info> &classes)
 {    
-    // Loop through all the classes we are looking at to see if there is an alias we should be done.
+    // Loop through all the classes we are looking at to see if there is an alias.
     for (auto &&c : classes)
     {
         for (auto &&m : c.methods)

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -6,6 +6,7 @@
 #include "TClassTable.h"
 
 #include <algorithm>
+#include <regex>
 #include <iterator>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
@@ -212,7 +213,8 @@ typename_info parse_typename(const string &type_name)
     typename_info result;
     result.is_const = false;
     result.is_pointer = false;
-    result.nickname = trim(type_name);
+    std::regex multi_space_regex("\\s+");
+    result.nickname = trim(regex_replace(type_name, multi_space_regex, " "));
     bool top_level_is_const = false;
 
     // Simple bail if this is a blank.
@@ -289,13 +291,14 @@ typename_info parse_typename(const string &type_name)
                     if (n1 == "const") {
                         top_level_is_const = true;
                         name = "";
-                    } else {
-                        name += type_name[t_index];
+                        break;
                     }
-                } else {
-                    name += type_name[t_index];
                 }
-            
+                if (!name.empty() && name.back() != ' ') {
+                    name += ' ';
+                }
+                break;
+
             case '&':
                 // We don't care about reference modifiers for this work.
                 if (ns_depth != 0) {

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -465,6 +465,19 @@ typename_info container_of(const class_info &ci) {
     throw runtime_error("Do not know how to find container type for class " + ci.name);
 }
 
+// Return a list of the C++ types that this type refers to in its
+// type name. This will unwind all the template arguments and return them as a set.
+// Does not return the typename that is itself.
+set<string> type_referenced_types(const typename_info &t) {
+    set<string> result;
+    for (auto &&t_arg : t.template_arguments) {
+        result.insert(unqualified_typename(t_arg));
+        auto t_args = type_referenced_types(t_arg);
+        result.insert(t_args.begin(), t_args.end());
+    }
+    return result;
+}
+
 // Return the C++ type as unqualified.
 std::string unqualified_typename(const typename_info &ti)
 {

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -228,7 +228,7 @@ typename_info parse_typename(const string &type_name)
         switch (type_name[t_index]) {
             case '<':
                 if (ns_depth == 0) {
-                    result.type_name = name;
+                    result.type_name = boost::trim_copy(name);
                     name = "";
                 } else {
                     name += type_name[t_index];

--- a/tests/t_translate.cpp
+++ b/tests/t_translate.cpp
@@ -114,3 +114,13 @@ TEST(t_translate, enum_calo) {
     EXPECT_EQ(it2 == it->values.end(), false);
     EXPECT_EQ(it2->second, 3);
 }
+
+TEST(t_translate, muon_container) {
+    // Make sure we can translates something like ElementLink<xAOD::MuonContainer>
+    // when we've not already loaded muon container.
+    // WARNING: the test can't load muon container anywhere else!
+
+    auto info = translate_class("ElementLink<xAOD::MuonContainer>");
+
+    EXPECT_EQ(info.name, "ElementLink<DataVector<xAOD::Muon_v1>>");
+}

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -593,3 +593,34 @@ TEST(t_type_helpers, parent_class_vector) {
     EXPECT_EQ(p.nickname, expected.nickname);
     EXPECT_EQ(p.template_arguments.size(), expected.template_arguments.size());
 }
+
+TEST(t_type_helpers, referenced_types_simple)
+{
+    auto t = parse_typename("int");
+    auto r = type_referenced_types(t);
+    EXPECT_EQ(r.size(), 0);
+}
+
+TEST(t_type_helpers, referenced_types_blank)
+{
+    auto t = parse_typename("");
+    auto r = type_referenced_types(t);
+    EXPECT_EQ(r.size(), 0);
+}
+
+TEST(t_type_helpers, referenced_types_vector)
+{
+    auto t = parse_typename("std::vector<int>");
+    auto r = type_referenced_types(t);
+    EXPECT_EQ(r.size(), 1);
+    EXPECT_EQ(r.find("int") != r.end(), true);
+}
+
+TEST(t_type_helpers, referenced_types_nested_vector)
+{
+    auto t = parse_typename("std::vector<ElementLink<int>>");
+    auto r = type_referenced_types(t);
+    EXPECT_EQ(r.size(), 2);
+    EXPECT_EQ(r.find("int") != r.end(), true);
+    EXPECT_EQ(r.find("ElementLink<int>") != r.end(), true);
+}

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -181,7 +181,37 @@ TEST(t_type_helpers, type_multiple_template_args) {
     EXPECT_EQ(t.template_arguments[1].type_name, "allocate");
 }
 
-TEST(t_type_helpers, type_const_on_top) {
+TEST(t_type_helpers, type_multiple_template_args_with_spaces)
+{
+    auto t = parse_typename("vector<std::size_t,       std::allocate<std::size_t>>");
+
+    EXPECT_EQ(t.type_name, "vector");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+
+    EXPECT_EQ(t.template_arguments.size(), 2);
+    EXPECT_EQ(t.template_arguments[0].type_name, "size_t");
+    EXPECT_EQ(t.template_arguments[1].type_name, "allocate");
+    EXPECT_EQ(t.template_arguments[0].namespace_list.size(), 1);
+    EXPECT_EQ(t.template_arguments[0].namespace_list[0].type_name, "std");
+}
+
+TEST(t_type_helpers, type_multiple_template_args_with_spaces_no_ns)
+{
+    auto t = parse_typename("vector<std::size_t,       allocate<std::size_t>>");
+
+    EXPECT_EQ(t.type_name, "vector");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+
+    EXPECT_EQ(t.template_arguments.size(), 2);
+    EXPECT_EQ(t.template_arguments[0].type_name, "size_t");
+    EXPECT_EQ(t.template_arguments[1].type_name, "allocate");
+    EXPECT_EQ(t.template_arguments[1].namespace_list.size(), 0);
+}
+
+TEST(t_type_helpers, type_const_on_top)
+{
     auto t = parse_typename("const DataVector<xAOD::SlowMuon_v1, DataModel_detail::NoBase>::PtrVector");
 
     EXPECT_EQ(t.type_name, "PtrVector");

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -16,7 +16,16 @@ TEST(t_type_helpers, type_int) {
     EXPECT_EQ(t.is_const, false);
 }
 
-TEST(t_type_helpers, type_int_ptr) {
+TEST(t_type_helpers, type_int_spaces)
+{
+    auto t1 = parse_typename(" int");
+    EXPECT_EQ(t1.type_name, "int");
+    auto t2 = parse_typename("int ");
+    EXPECT_EQ(t1.type_name, "int");
+}
+
+TEST(t_type_helpers, type_int_ptr)
+{
     auto t = parse_typename("int*");
 
     EXPECT_EQ(t.namespace_list.size(), 0);
@@ -69,6 +78,15 @@ TEST(t_type_helpers, type_vector_int) {
     EXPECT_EQ(t.type_name, "vector");
 }
 
+TEST(t_type_helpers, type_vector_int_spaces)
+{
+    auto t = parse_typename("vector< int >");
+
+    EXPECT_EQ(t.template_arguments.size(), 1);
+    auto sub_t = t.template_arguments[0];
+    EXPECT_EQ(sub_t.type_name, "int");
+    EXPECT_EQ(t.type_name, "vector");
+}
 
 // Simple typename qualified by namespace
 TEST(t_type_helpers, type_namespaced_type) {

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -65,6 +65,50 @@ TEST(t_type_helpers, type_int_const) {
     EXPECT_EQ(t.is_const, true);
 }
 
+TEST(t_type_helpers, type_int_const_spaces)
+{
+    auto t = parse_typename("const   int");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "const int");
+    EXPECT_EQ(t.is_const, true);
+}
+
+TEST(t_type_helpers, type_unsigned_int)
+{
+    auto t = parse_typename("unsigned int");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "unsigned int");
+    EXPECT_EQ(t.nickname, "unsigned int");
+    EXPECT_EQ(t.is_const, false);
+}
+
+TEST(t_type_helpers, type_unsigned_int_spaces)
+{
+    auto t = parse_typename("unsigned   int");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "unsigned int");
+    EXPECT_EQ(t.nickname, "unsigned int");
+    EXPECT_EQ(t.is_const, false);
+}
+
+TEST(t_type_helpers, type_const_unsigned_int)
+{
+    auto t = parse_typename("const unsigned int");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "unsigned int");
+    EXPECT_EQ(t.nickname, "const unsigned int");
+    EXPECT_EQ(t.is_const, true);
+}
+
 // Simple template
 TEST(t_type_helpers, type_vector_int) {
     auto t = parse_typename("vector<int>");
@@ -260,7 +304,8 @@ TEST(t_type_helpers, typedef_resolve_utin32) {
     EXPECT_EQ(resolve_typedef("uint32_t"), "unsigned int");
 }
 
-TEST(t_type_helpers, typedef_resolve_ulong64) {
+TEST(t_type_helpers, typedef_resolve_ulong64)
+{
     EXPECT_EQ(resolve_typedef("ULong64_t"), "unsigned long long");
 }
 
@@ -405,7 +450,8 @@ TEST(t_type_helpers, cpp_string_simple_pointer) {
     EXPECT_EQ(typename_cpp_string(parse_typename("int*")), "int *");
 }
 
-TEST(t_type_helpers, cpp_string_simple_const) {
+TEST(t_type_helpers, cpp_string_simple_const)
+{
     EXPECT_EQ(typename_cpp_string(parse_typename("const int*")), "const int *");
 }
 


### PR DESCRIPTION
Making sure we have a way to add types that are needed by BLS, like `std::vector<ElementLink<xAOD::MuonContainer>>`

# Main Changes

* Make sure to load template arguments from `TClass::Get` before loading the template class
  * If you do it in wrong order ROOT will claim ignorance.
* Bug fix: spaces in second (or later) arguments in templates were being included in type name.
* Bug fix: Fix up spaces between "unsigned" and "int" so that "unsigned    int" is "unsigned int".
* Make sure command line requested types aren't dropped even if they aren't connected to a container
* Added `required_classes.txt` in the `scripts` directory where we can put, by hand, any extra classes required.

# Minor Updates

* Added a helper function to return all types referenced in a type.
* Added tests to make sure simple parsing with spaces wasn't failing.

Fixes #21
