### PR TITLE
Improve const parsing for type names

### DIFF
--- a/include/class_info.hpp
+++ b/include/class_info.hpp
@@ -24,6 +24,10 @@ struct typename_info {
 
     // Is this a pointer?
     bool is_pointer;
+
+    // And if this is a point, is a const pointer?
+    // int * const
+    bool is_const_pointer;
 };
 
 struct method_arg {

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -215,6 +215,7 @@ typename_info parse_typename(const string &type_name)
     typename_info result;
     result.is_const = false;
     result.is_pointer = false;
+    result.is_const_pointer = false;
     result.nickname = trim(regex_replace(type_name, _multi_space_regex, " "));
     bool top_level_is_const = false;
 
@@ -289,9 +290,13 @@ typename_info parse_typename(const string &type_name)
             case ' ':
                 if (ns_depth == 0) {
                     auto n1 = boost::trim_copy(name);
-                    if (n1 == "const") {
-                        top_level_is_const = true;
-                        name = "";
+                    if (boost::ends_with(n1, "const")) {
+                        if (result.is_pointer) {
+                            result.is_const_pointer = true;
+                        } else {
+                            top_level_is_const = true;
+                        }
+                        name = boost::trim_copy(name.substr(0, name.size() - 5));
                         break;
                     }
                 }
@@ -312,6 +317,14 @@ typename_info parse_typename(const string &type_name)
                 break;
         }
         t_index++;
+    }
+    if (boost::ends_with(name, "const")) {
+        if (result.is_pointer) {
+            result.is_const_pointer = true;
+        } else {
+            top_level_is_const = true;
+        }
+        name = name.substr(0, name.size() - 5);
     }
     if (name.size() > 0 && result.type_name.size() == 0) {
         boost::trim(name);

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -53,15 +53,91 @@ TEST(t_type_helpers, type_int_ptr_space) {
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.nickname, "int *");
     EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
 }
 
-TEST(t_type_helpers, type_int_const) {
+TEST(t_type_helpers, type_int_ptr_const)
+{
+    auto t = parse_typename("const int *");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "const int *");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, true);
+    EXPECT_EQ(t.is_const_pointer, false);
+}
+
+TEST(t_type_helpers, type_int_ptr_const_2)
+{
+    auto t = parse_typename("int const *");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "int const *");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, true);
+    EXPECT_EQ(t.is_const_pointer, false);
+}
+
+TEST(t_type_helpers, type_int_const_ptr_space)
+{
+    auto t = parse_typename("int * const ");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "int * const");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
+    EXPECT_EQ(t.is_const_pointer, true);
+}
+
+TEST(t_type_helpers, type_int_const_ptr)
+{
+    auto t = parse_typename("int * const ");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "int * const");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
+    EXPECT_EQ(t.is_const_pointer, true);
+}
+
+TEST(t_type_helpers, type_int_const)
+{
     auto t = parse_typename("const int");
 
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.nickname, "const int");
+    EXPECT_EQ(t.is_const, true);
+}
+
+TEST(t_type_helpers, type_int_const_2)
+{
+    auto t = parse_typename("int const");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "int const");
+    EXPECT_EQ(t.is_const, true);
+}
+
+TEST(t_type_helpers, type_int_const_3)
+{
+    auto t = parse_typename("int const ");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.nickname, "int const");
     EXPECT_EQ(t.is_const, true);
 }
 


### PR DESCRIPTION
Enhance the parsing logic to correctly identify const pointers and add corresponding tests to validate the changes.

Fixes #25