### PR TITLE
Rename nickname to cpp_name and fix const emission bug

### DIFF
--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -75,7 +75,7 @@ bool check_template_arguments(const typename_info &info, const set<string> &clas
                 return false;
             }
         } else {
-            if (classes_to_emit.find(ta.nickname) == classes_to_emit.end()) {
+            if (classes_to_emit.find(ta.cpp_name) == classes_to_emit.end()) {
                 return false;
             }
         }
@@ -132,15 +132,15 @@ string extract_container_iterator_type(const collection_info &c)
 {
     switch (c.iterator_type_info.template_arguments.size()) {
         case 0:
-            return c.iterator_type_info.nickname;
+            return c.iterator_type_info.cpp_name;
             break;
         
         case 1:
-            return c.iterator_type_info.template_arguments[0].nickname;
+            return c.iterator_type_info.template_arguments[0].cpp_name;
             break;
         
         default:
-            throw runtime_error("Do not know how to deal with the collection of iterator type " + c.iterator_type_info.nickname);
+            throw runtime_error("Do not know how to deal with the collection of iterator type " + c.iterator_type_info.cpp_name);
     }
 }
 
@@ -498,7 +498,7 @@ int main(int argc, char**argv) {
             << YAML::Key << "collection_name" << YAML::Value << c.name
             << YAML::Key << "cpp_item_type" << YAML::Value << extract_container_iterator_type(c)
             << YAML::Key << "python_item_type" << YAML::Value << normalized_type_name(extract_container_iterator_type(c))
-            << YAML::Key << "cpp_container_type" << YAML::Value << c.type_info.nickname
+            << YAML::Key << "cpp_container_type" << YAML::Value << c.type_info.cpp_name
             << YAML::Key << "python_container_type" << YAML::Value << normalized_type_name(c.iterator_type_info)
             << YAML::Key << "include_file" << YAML::Value << c.include_file
             << YAML::Key << "link_libraries" << YAML::Value << YAML::BeginSeq;
@@ -604,11 +604,11 @@ int main(int argc, char**argv) {
         // If we can dump the class, then we should!
         out << YAML::BeginMap
             << YAML::Key << "python_name" << YAML::Value << normalized_type_name(c_info->second.name_as_type)
-            << YAML::Key << "cpp_name" << YAML::Value << c_info->second.name_as_type.nickname;
+            << YAML::Key << "cpp_name" << YAML::Value << c_info->second.name_as_type.cpp_name;
                 
         if (is_collection(c_info->second)) {
             auto container_typename = container_of(c_info->second);
-            out << YAML::Key << "is_container_of_cpp" << YAML::Value << container_typename.nickname;
+            out << YAML::Key << "is_container_of_cpp" << YAML::Value << container_typename.cpp_name;
             out << YAML::Key << "is_container_of_python" << YAML::Value << normalized_type_name(container_typename);
         }
         
@@ -664,7 +664,7 @@ int main(int argc, char**argv) {
                 auto rtn_type = parse_typename(meth.return_type);
                 out << YAML::BeginMap
                     << YAML::Key << "name" << YAML::Value << meth.name
-                    << YAML::Key << "return_type" << YAML::Value << rtn_type.nickname;
+                    << YAML::Key << "return_type" << YAML::Value << rtn_type.cpp_name;
 
                 dump_arguments("arguments", meth.arguments, out);
                 dump_arguments("parameter_arguments", meth.parameter_arguments, out);

--- a/include/class_info.hpp
+++ b/include/class_info.hpp
@@ -17,7 +17,7 @@ struct typename_info {
 
     // The full name of the type, including all qualifiers
     // int, int*, std::vector<std::jet>&, const int &, etc.
-    std::string nickname;
+    std::string cpp_name;
 
     // Is this a const decl?
     bool is_const;

--- a/include/class_info.hpp
+++ b/include/class_info.hpp
@@ -5,6 +5,14 @@
 #include <iostream>
 #include <vector>
 
+struct pointer_info {
+    // True if the pointer is const -
+    // for example, "int * const", will have this set to
+    // true, and "int *" will have this set to false.
+    bool is_const;
+};
+
+
 struct typename_info {
     // The list of identifiers separated by "::"
     std::vector<typename_info> namespace_list;
@@ -25,9 +33,8 @@ struct typename_info {
     // Is this a pointer?
     bool is_pointer;
 
-    // And if this is a point, is a const pointer?
-    // int * const
-    bool is_const_pointer;
+    // Pointer info
+    std::vector<pointer_info> p_info;
 };
 
 struct method_arg {

--- a/include/class_info.hpp
+++ b/include/class_info.hpp
@@ -9,7 +9,7 @@ struct typename_info {
     // The list of identifiers separated by "::"
     std::vector<typename_info> namespace_list;
 
-    // The actual type name
+    // The actual type name ("vector" in std::vector<int>, for example)
     std::string type_name;
 
     // The template arguments (if there are any)

--- a/include/class_info.hpp
+++ b/include/class_info.hpp
@@ -30,10 +30,7 @@ struct typename_info {
     // Is this a const decl?
     bool is_const;
 
-    // Is this a pointer?
-    bool is_pointer;
-
-    // Pointer info
+    // Pointer info - for each "*" we push info.
     std::vector<pointer_info> p_info;
 };
 

--- a/include/type_helpers.hpp
+++ b/include/type_helpers.hpp
@@ -76,4 +76,8 @@ bool is_understood_method(const method_info &meth, const std::set<std::string> &
 // Return the python version of the typename.
 typename_info py_typename(const std::string &t_name);
 typename_info py_typename(const typename_info &t);
+
+// Return a TClass, but skip internal classes.
+class TClass;
+TClass *get_tclass(const std::string &name);
 #endif

--- a/src/class_info.cpp
+++ b/src/class_info.cpp
@@ -177,8 +177,8 @@ std::vector<std::string> referenced_types(const typename_info &t_info)
     }
 
     // And the top level name, but make sure it is "legal"
-    if (!all_of(t_info.nickname.begin(), t_info.nickname.end(), ::isdigit)
-        && (t_info.nickname[0] != '-')
+    if (!all_of(t_info.cpp_name.begin(), t_info.cpp_name.end(), ::isdigit)
+        && (t_info.cpp_name[0] != '-')
         )
         result.insert(unqualified_typename(t_info));
 

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -244,7 +244,7 @@ class_info translate_class(const std::string &class_name)
         return result;
     }
 
-    result.name = typename_cpp_string(t);
+    result.name = t.cpp_name;
     result.name_as_type = t;
 
     // Special case a vector.

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -270,7 +270,7 @@ class_info translate_class(const std::string &class_name)
         isValid_method.name = "isValid";
         isValid_method.return_type = "bool";
         result.methods.push_back(isValid_method);
-        result.class_behaviors.push_back(t.template_arguments[0].template_arguments[0].nickname + "**");
+        result.class_behaviors.push_back(t.template_arguments[0].template_arguments[0].cpp_name + "**");
         return result;
     }
 
@@ -332,8 +332,8 @@ class_info translate_class(const std::string &class_name)
     string include ("");
     if (include == "") {
         auto dv_info = get_first_class(result, "DataVector");
-        if (dv_info.nickname.size() > 0) {
-            include = get_include_file_for_container(class_name, dv_info.nickname);
+        if (dv_info.cpp_name.size() > 0) {
+            include = get_include_file_for_container(class_name, dv_info.cpp_name);
             if (include.size() > 0 && !include_file_exists(include)) {
                 include = "";
             }

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -117,7 +117,7 @@ vector<string> inherited_public_classes(TClass *c_info) {
 }
 
 vector<string> inherited_public_classes(const std::string &cls_name) {
-    auto c_info = TClass::GetClass(cls_name.c_str());
+    auto c_info = get_tclass(cls_name);
     if (c_info != nullptr) {
         return inherited_public_classes(c_info);
     } else {
@@ -164,7 +164,7 @@ string clean_so_name(string original_name)
 // heuristics to get it right.
 string get_include_file_for_class(const string &class_name)
 {
-    auto c_info = TClass::GetClass(class_name.c_str());
+    auto c_info = get_tclass(class_name);
     if (c_info == nullptr) {
         return "";
     }
@@ -188,7 +188,7 @@ string get_include_file_for_container(const string &class_name, const string &ra
     auto object_name = std::regex_replace(raw_object_name, std::regex("_v[0-9]+$"), "");
     auto parsed_info = parse_typename(object_name);
 
-    auto c_info = TClass::GetClass(class_name.c_str());
+    auto c_info = get_tclass(class_name);
     if (c_info == nullptr) {
         return "";
     }
@@ -211,10 +211,11 @@ void load_template_arguments(const vector<typename_info> &types) {
     // even though it knows about all of that.
     for (auto &&t : types)
     {
-        if (TClass::GetClass(unqualified_typename(t).c_str()) == nullptr) {
+        if (get_tclass(unqualified_typename(t)) == nullptr)
+        {
             // If we can't load it, then load template arguments first.
             load_template_arguments(t.template_arguments);
-            TClass::GetClass(unqualified_typename(t).c_str());
+            get_tclass(unqualified_typename(t));
         }
     }
 }
@@ -228,8 +229,8 @@ class_info translate_class(const std::string &class_name)
 
     // Get the class
     class_info result;
-    auto unq_class_name = unqualified_type_name(class_name);
-    auto c_info = TClass::GetClass(unq_class_name.c_str());
+    auto unq_class_name = unqualified_typename(t_prior);
+    auto c_info = get_tclass(unq_class_name);
     if (c_info == nullptr)
     {
         std::cerr << "ERROR: Cannot translate class '" << class_name << "': ROOT's type system doesn't have it loaded as a class." << std::endl;

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -264,11 +264,14 @@ typename_info parse_typename(const string &type_name)
                     if (name.size() > 0) {
                         result.namespace_list.push_back(parse_typename(name));
                         name = "";
-                    } else {
+                    }
+                    else
+                    {
+                        result.cpp_name = typename_cpp_string(result);
                         typename_info nested_ns = result;
                         result = typename_info();
 
-                        // result.cpp_name = nested_ns.cpp_name;
+                        result.cpp_name = nested_ns.cpp_name;
                         // nested_ns.cpp_name = nested_ns.cpp_name.substr(0, t_index);
 
                         result.namespace_list.push_back(nested_ns);

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -151,7 +151,7 @@ string resolve_typedef(const string &c_name) {
     }
 
     // Last is to normalize, if possible, with a class name
-    auto c = TClass::GetClass(result.c_str());
+    auto c = get_tclass(result);
     if (c != nullptr) {
         result = c->GetName();
     }
@@ -482,7 +482,7 @@ typename_info container_of(const class_info &ci) {
             return parse_typename(rtn_type->second);
         }
 
-        auto &&c = TClass::GetClass(rtn_type_name.c_str());
+        auto &&c = get_tclass(rtn_type_name);
         if (c != nullptr) {
             return parse_typename(c->GetName());
         } else {
@@ -704,4 +704,20 @@ typename_info parent_class(const typename_info &ti)
     result.cpp_name = typename_cpp_string(result);
 
     return result;
+}
+
+// Get a TClass pointer, but protect against fetching
+// internal classes.
+TClass *get_tclass(const string &name)
+{
+    // Any type that looks like it has something internal,
+    // like __gnu_cxx::xxxx. ROOT has some issue with these,
+    // printing out error messages to cout (rather than cerr),
+    // which pollutes out output, of course. We don't need them,
+    // so avoid them.
+    if (name.find("__") != string::npos) {
+        return nullptr;
+    }
+
+    return TClass::GetClass(name.c_str());
 }

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -546,6 +546,9 @@ std::string typename_cpp_string(const typename_info &ti)
 
     if (ti.is_pointer) {
         stream << " *";
+        if (ti.is_const_pointer) {
+            stream << " const";
+        }
     }
 
     return stream.str();

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -524,7 +524,7 @@ std::string typename_cpp_string(const typename_info &ti)
         if (!first)
             stream << "::";
         first = false;
-        stream << typename_cpp_string(ns);
+        stream << ns.cpp_name;
     }
     if (!first)
         stream << "::";
@@ -541,7 +541,7 @@ std::string typename_cpp_string(const typename_info &ti)
         } else {
             stream << ", ";
         }
-        stream << typename_cpp_string(t_arg);
+        stream << t_arg.cpp_name;
     }
     if (!first) {
         stream << ">";

--- a/src/xaod_helpers.cpp
+++ b/src/xaod_helpers.cpp
@@ -63,16 +63,16 @@ collection_info get_collection_info(const class_info &c, const vector<class_info
     // The iterator looks at the thing we are looking at. This needs to be a DataVector.
     ostringstream it_name;
     auto item = get_first_class(c, "DataVector");
-    it_name << "Iterable<" << item.nickname << ">";
+    it_name << "Iterable<" << item.cpp_name << ">";
 
     // And we need to fetch the include file for the collections too.
     r.include_file = c.include_file;
 
     // The library is just the prefix on the include for the cpp item
     auto cls_ptr = find_if(all_classes.begin(), all_classes.end(),
-        [item](const class_info &a_class_item){return a_class_item.name == item.nickname;});
+        [item](const class_info &a_class_item){return a_class_item.name == item.cpp_name;});
     if (cls_ptr == all_classes.end()) {
-        throw runtime_error("Cannot find class " + item.nickname + " in ROOT's class list when trying to create collection " + c.name + ".");
+        throw runtime_error("Cannot find class " + item.cpp_name + " in ROOT's class list when trying to create collection " + c.name + ".");
     }
     r.link_libraries.push_back(cls_ptr->library_name);
 

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -12,7 +12,6 @@ TEST(t_type_helpers, type_int) {
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.is_pointer, false);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -32,7 +31,6 @@ TEST(t_type_helpers, type_int_ptr)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int *");
-    EXPECT_EQ(t.is_pointer, true);
 }
 
 TEST(t_type_helpers, type_int_ref) {
@@ -43,7 +41,6 @@ TEST(t_type_helpers, type_int_ref) {
     EXPECT_EQ(t.type_name, "int");
     // We do not care about reference modifiers here.
     EXPECT_EQ(t.cpp_name, "int");
-    EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, type_int_ptr_space) {
@@ -53,7 +50,6 @@ TEST(t_type_helpers, type_int_ptr_space) {
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int *");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -65,7 +61,6 @@ TEST(t_type_helpers, type_int_ptr_const)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "const int *");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -77,7 +72,6 @@ TEST(t_type_helpers, type_int_ptr_const_2)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "const int *");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -89,7 +83,6 @@ TEST(t_type_helpers, type_int_const_ptr_space)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int * const");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -101,7 +94,6 @@ TEST(t_type_helpers, type_int_const_ptr)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int * const");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -113,7 +105,6 @@ TEST(t_type_helpers, type_int_2ptr)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int * *");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -125,7 +116,6 @@ TEST(t_type_helpers, type_int_ptr_const_ptr)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int * const *");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -137,7 +127,6 @@ TEST(t_type_helpers, type_int_ptr_ptr_const)
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
     EXPECT_EQ(t.cpp_name, "int * * const");
-    EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -666,31 +655,26 @@ TEST(t_type_helpers, understood_method_template) {
 TEST(t_type_helpers, py_type_simple_type) {
     auto t = py_typename("int");
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, py_type_vector) {
     auto t = py_typename("vector<int>");
     EXPECT_EQ(t.cpp_name, "Iterable<int>");
-    EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, py_type_element_link) {
     auto t = py_typename("ElementLink<DataVector<int>>");
     EXPECT_EQ(t.cpp_name, "int *");
-    EXPECT_EQ(t.is_pointer, true);
 }
 
 TEST(t_type_helpers, py_type_dv) {
     auto t = py_typename("DataVector<int>");
     EXPECT_EQ(t.cpp_name, "Iterable<int>");
-    EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, py_type_dv_el) {
     auto t = py_typename("vector<ElementLink<DataVector<int>>>");
     EXPECT_EQ(t.cpp_name, "Iterable<int *>");
-    EXPECT_EQ(t.is_pointer, false);
 }
 // TODO: Remove py_typename, not used.
 
@@ -757,7 +741,6 @@ TEST(t_type_helpers, parent_class_three) {
     EXPECT_EQ(p.namespace_list[0].type_name, "std");
     EXPECT_EQ(p.template_arguments.size(), 0);
     EXPECT_EQ(p.is_const, false);
-    EXPECT_EQ(p.is_pointer, false);
     EXPECT_EQ(p.cpp_name, "std::org");
 }
 
@@ -771,7 +754,6 @@ TEST(t_type_helpers, parent_class_const_ptr) {
     EXPECT_EQ(p.cpp_name, "std::org");
     EXPECT_EQ(p.template_arguments.size(), 0);
     EXPECT_EQ(p.is_const, false);
-    EXPECT_EQ(p.is_pointer, false);
 }
 
 TEST(t_type_helpers, parent_class_none) {

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -31,7 +31,7 @@ TEST(t_type_helpers, type_int_ptr)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.cpp_name, "int*");
+    EXPECT_EQ(t.cpp_name, "int *");
     EXPECT_EQ(t.is_pointer, true);
 }
 
@@ -41,7 +41,8 @@ TEST(t_type_helpers, type_int_ref) {
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.cpp_name, "int&");
+    // We do not care about reference modifiers here.
+    EXPECT_EQ(t.cpp_name, "int");
     EXPECT_EQ(t.is_pointer, false);
 }
 
@@ -76,7 +77,7 @@ TEST(t_type_helpers, type_int_ptr_const_2)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.cpp_name, "int const *");
+    EXPECT_EQ(t.cpp_name, "const int *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
     EXPECT_EQ(t.is_const_pointer, false);
@@ -126,7 +127,7 @@ TEST(t_type_helpers, type_int_const_2)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.cpp_name, "int const");
+    EXPECT_EQ(t.cpp_name, "const int");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -137,7 +138,7 @@ TEST(t_type_helpers, type_int_const_3)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.cpp_name, "int const");
+    EXPECT_EQ(t.cpp_name, "const int");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -496,7 +497,7 @@ TEST(t_type_helpers, container_of_begin_end_JetVertexConst) {
 
     auto t = container_of(ci);
 
-    EXPECT_EQ(t.cpp_name, "xAOD::JetConstituent*");
+    EXPECT_EQ(t.cpp_name, "xAOD::JetConstituent *");
 }
 
 TEST(t_type_helpers, container_of_vector) {

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -31,7 +31,7 @@ TEST(t_type_helpers, type_int_ptr)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int*");
+    EXPECT_EQ(t.cpp_name, "int*");
     EXPECT_EQ(t.is_pointer, true);
 }
 
@@ -41,7 +41,7 @@ TEST(t_type_helpers, type_int_ref) {
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int&");
+    EXPECT_EQ(t.cpp_name, "int&");
     EXPECT_EQ(t.is_pointer, false);
 }
 
@@ -51,7 +51,7 @@ TEST(t_type_helpers, type_int_ptr_space) {
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int *");
+    EXPECT_EQ(t.cpp_name, "int *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
 }
@@ -63,7 +63,7 @@ TEST(t_type_helpers, type_int_ptr_const)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "const int *");
+    EXPECT_EQ(t.cpp_name, "const int *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
     EXPECT_EQ(t.is_const_pointer, false);
@@ -76,7 +76,7 @@ TEST(t_type_helpers, type_int_ptr_const_2)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int const *");
+    EXPECT_EQ(t.cpp_name, "int const *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
     EXPECT_EQ(t.is_const_pointer, false);
@@ -89,7 +89,7 @@ TEST(t_type_helpers, type_int_const_ptr_space)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int * const");
+    EXPECT_EQ(t.cpp_name, "int * const");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
     EXPECT_EQ(t.is_const_pointer, true);
@@ -102,7 +102,7 @@ TEST(t_type_helpers, type_int_const_ptr)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int * const");
+    EXPECT_EQ(t.cpp_name, "int * const");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
     EXPECT_EQ(t.is_const_pointer, true);
@@ -115,7 +115,7 @@ TEST(t_type_helpers, type_int_const)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "const int");
+    EXPECT_EQ(t.cpp_name, "const int");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -126,7 +126,7 @@ TEST(t_type_helpers, type_int_const_2)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int const");
+    EXPECT_EQ(t.cpp_name, "int const");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -137,7 +137,7 @@ TEST(t_type_helpers, type_int_const_3)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "int const");
+    EXPECT_EQ(t.cpp_name, "int const");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -148,7 +148,7 @@ TEST(t_type_helpers, type_int_const_spaces)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "int");
-    EXPECT_EQ(t.nickname, "const int");
+    EXPECT_EQ(t.cpp_name, "const int");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -159,7 +159,7 @@ TEST(t_type_helpers, type_unsigned_int)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "unsigned int");
-    EXPECT_EQ(t.nickname, "unsigned int");
+    EXPECT_EQ(t.cpp_name, "unsigned int");
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -170,7 +170,7 @@ TEST(t_type_helpers, type_unsigned_int_spaces)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "unsigned int");
-    EXPECT_EQ(t.nickname, "unsigned int");
+    EXPECT_EQ(t.cpp_name, "unsigned int");
     EXPECT_EQ(t.is_const, false);
 }
 
@@ -181,7 +181,7 @@ TEST(t_type_helpers, type_const_unsigned_int)
     EXPECT_EQ(t.namespace_list.size(), 0);
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.type_name, "unsigned int");
-    EXPECT_EQ(t.nickname, "const unsigned int");
+    EXPECT_EQ(t.cpp_name, "const unsigned int");
     EXPECT_EQ(t.is_const, true);
 }
 
@@ -229,7 +229,7 @@ TEST(t_type_helpers, type_namespaced_type_twice) {
     auto t = parse_typename("std::org::size_t");
 
     EXPECT_EQ(t.type_name, "size_t");
-    EXPECT_EQ(t.nickname, "std::org::size_t");
+    EXPECT_EQ(t.cpp_name, "std::org::size_t");
 
     EXPECT_EQ(t.namespace_list.size(), 2);
     auto t_ns = t.namespace_list[0];
@@ -272,11 +272,11 @@ TEST(t_type_helpers, type_namespaced_buried) {
 TEST(t_type_helpers, type_qualified_typename) {
     auto t = parse_typename("vector<float>::size_t");
 
-    EXPECT_EQ(t.nickname, "vector<float>::size_t");
+    EXPECT_EQ(t.cpp_name, "vector<float>::size_t");
     EXPECT_EQ(t.type_name, "size_t");
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.namespace_list.size(), 1);
-    EXPECT_EQ(t.namespace_list[0].nickname, "vector<float>");
+    EXPECT_EQ(t.namespace_list[0].cpp_name, "vector<float>");
 }
 
 
@@ -284,7 +284,7 @@ TEST(t_type_helpers, type_qualified_typename) {
 TEST(t_type_helpers, type_whitespace) {
     auto t = parse_typename("vector<float>::size_t ");
 
-    EXPECT_EQ(t.nickname, "vector<float>::size_t");
+    EXPECT_EQ(t.cpp_name, "vector<float>::size_t");
 }
 
 
@@ -421,26 +421,26 @@ TEST(t_type_helpers, typedef_fixup_methods) {
 TEST(t_type_helpers, is_collection_int) {
     typename_info ti;
     ti.type_name = "int";
-    ti.nickname = "int";
+    ti.cpp_name = "int";
     EXPECT_EQ(is_collection(ti), false);
 }
 
 TEST(t_type_helpers, is_collection_vector) {
     typename_info ti_int;
     ti_int.type_name = "int";
-    ti_int.nickname = "int";
+    ti_int.cpp_name = "int";
 
     typename_info ti;
     ti.type_name = "vector";
-    ti.nickname = "vector<int>";
+    ti.cpp_name = "vector<int>";
     ti.template_arguments.push_back(ti_int);
     EXPECT_EQ(is_collection(ti), true);
 }
 
 TEST(t_type_helpers, is_collection_simple_class) {
     typename_info ti;
-    ti.nickname = "dude";
-    ti.nickname = "dude";
+    ti.cpp_name = "dude";
+    ti.cpp_name = "dude";
 
     class_info ci;
     ci.name = "dude";
@@ -451,13 +451,13 @@ TEST(t_type_helpers, is_collection_simple_class) {
 
 TEST(t_type_helpers, container_of_begin_end_TIter) {
     typename_info ti;
-    ti.nickname = "dude";
-    ti.nickname = "dude";
+    ti.cpp_name = "dude";
+    ti.cpp_name = "dude";
 
     class_info ci;
     ci.name = "MyVector";
     ci.name_as_type.type_name = "MyVector";
-    ci.name_as_type.nickname = "MyVector";
+    ci.name_as_type.cpp_name = "MyVector";
 
     // Add begin/end vector here
     method_info m_begin;
@@ -471,18 +471,18 @@ TEST(t_type_helpers, container_of_begin_end_TIter) {
 
     auto t = container_of(ci);
 
-    EXPECT_EQ(t.nickname, "TObject");
+    EXPECT_EQ(t.cpp_name, "TObject");
 }
 
 TEST(t_type_helpers, container_of_begin_end_JetVertexConst) {
     typename_info ti;
-    ti.nickname = "dude";
-    ti.nickname = "dude";
+    ti.cpp_name = "dude";
+    ti.cpp_name = "dude";
 
     class_info ci;
     ci.name = "MyVector";
     ci.name_as_type.type_name = "MyVector";
-    ci.name_as_type.nickname = "MyVector";
+    ci.name_as_type.cpp_name = "MyVector";
 
     // Add begin/end vector here
     method_info m_begin;
@@ -496,7 +496,7 @@ TEST(t_type_helpers, container_of_begin_end_JetVertexConst) {
 
     auto t = container_of(ci);
 
-    EXPECT_EQ(t.nickname, "xAOD::JetConstituent*");
+    EXPECT_EQ(t.cpp_name, "xAOD::JetConstituent*");
 }
 
 TEST(t_type_helpers, container_of_vector) {
@@ -515,7 +515,7 @@ TEST(t_type_helpers, container_of_vector) {
 
     auto t = container_of(ci);
 
-    EXPECT_EQ(t.nickname, "int");
+    EXPECT_EQ(t.cpp_name, "int");
 }
 
 TEST(t_type_helpers, cpp_string_simple) {
@@ -638,25 +638,25 @@ TEST(t_type_helpers, py_type_simple_type) {
 
 TEST(t_type_helpers, py_type_vector) {
     auto t = py_typename("vector<int>");
-    EXPECT_EQ(t.nickname, "Iterable<int>");
+    EXPECT_EQ(t.cpp_name, "Iterable<int>");
     EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, py_type_element_link) {
     auto t = py_typename("ElementLink<DataVector<int>>");
-    EXPECT_EQ(t.nickname, "int *");
+    EXPECT_EQ(t.cpp_name, "int *");
     EXPECT_EQ(t.is_pointer, true);
 }
 
 TEST(t_type_helpers, py_type_dv) {
     auto t = py_typename("DataVector<int>");
-    EXPECT_EQ(t.nickname, "Iterable<int>");
+    EXPECT_EQ(t.cpp_name, "Iterable<int>");
     EXPECT_EQ(t.is_pointer, false);
 }
 
 TEST(t_type_helpers, py_type_dv_el) {
     auto t = py_typename("vector<ElementLink<DataVector<int>>>");
-    EXPECT_EQ(t.nickname, "Iterable<int *>");
+    EXPECT_EQ(t.cpp_name, "Iterable<int *>");
     EXPECT_EQ(t.is_pointer, false);
 }
 // TODO: Remove py_typename, not used.
@@ -725,7 +725,7 @@ TEST(t_type_helpers, parent_class_three) {
     EXPECT_EQ(p.template_arguments.size(), 0);
     EXPECT_EQ(p.is_const, false);
     EXPECT_EQ(p.is_pointer, false);
-    EXPECT_EQ(p.nickname, "std::org");
+    EXPECT_EQ(p.cpp_name, "std::org");
 }
 
 TEST(t_type_helpers, parent_class_const_ptr) {
@@ -735,7 +735,7 @@ TEST(t_type_helpers, parent_class_const_ptr) {
     EXPECT_EQ(p.type_name, "org");
     EXPECT_EQ(p.namespace_list.size(), 1);
     EXPECT_EQ(p.namespace_list[0].type_name, "std");
-    EXPECT_EQ(p.nickname, "std::org");
+    EXPECT_EQ(p.cpp_name, "std::org");
     EXPECT_EQ(p.template_arguments.size(), 0);
     EXPECT_EQ(p.is_const, false);
     EXPECT_EQ(p.is_pointer, false);
@@ -760,7 +760,7 @@ TEST(t_type_helpers, parent_class_vector) {
 
     EXPECT_EQ(p.type_name, expected.type_name);
     EXPECT_EQ(p.namespace_list.size(), expected.namespace_list.size());
-    EXPECT_EQ(p.nickname, expected.nickname);
+    EXPECT_EQ(p.cpp_name, expected.cpp_name);
     EXPECT_EQ(p.template_arguments.size(), expected.template_arguments.size());
 }
 

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -67,7 +67,6 @@ TEST(t_type_helpers, type_int_ptr_const)
     EXPECT_EQ(t.cpp_name, "const int *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
-    EXPECT_EQ(t.is_const_pointer, false);
 }
 
 TEST(t_type_helpers, type_int_ptr_const_2)
@@ -80,7 +79,6 @@ TEST(t_type_helpers, type_int_ptr_const_2)
     EXPECT_EQ(t.cpp_name, "const int *");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, true);
-    EXPECT_EQ(t.is_const_pointer, false);
 }
 
 TEST(t_type_helpers, type_int_const_ptr_space)
@@ -93,7 +91,6 @@ TEST(t_type_helpers, type_int_const_ptr_space)
     EXPECT_EQ(t.cpp_name, "int * const");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
-    EXPECT_EQ(t.is_const_pointer, true);
 }
 
 TEST(t_type_helpers, type_int_const_ptr)
@@ -106,7 +103,42 @@ TEST(t_type_helpers, type_int_const_ptr)
     EXPECT_EQ(t.cpp_name, "int * const");
     EXPECT_EQ(t.is_pointer, true);
     EXPECT_EQ(t.is_const, false);
-    EXPECT_EQ(t.is_const_pointer, true);
+}
+
+TEST(t_type_helpers, type_int_2ptr)
+{
+    auto t = parse_typename("int **");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.cpp_name, "int * *");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
+}
+
+TEST(t_type_helpers, type_int_ptr_const_ptr)
+{
+    auto t = parse_typename("int * const *");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.cpp_name, "int * const *");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
+}
+
+TEST(t_type_helpers, type_int_ptr_ptr_const)
+{
+    auto t = parse_typename("int * * const");
+
+    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.template_arguments.size(), 0);
+    EXPECT_EQ(t.type_name, "int");
+    EXPECT_EQ(t.cpp_name, "int * * const");
+    EXPECT_EQ(t.is_pointer, true);
+    EXPECT_EQ(t.is_const, false);
 }
 
 TEST(t_type_helpers, type_int_const)

--- a/tests/t_xaod_helpers.cpp
+++ b/tests/t_xaod_helpers.cpp
@@ -36,7 +36,7 @@ TEST(t_xaod_helpers, normal_jet_collection) {
     EXPECT_EQ(r[0].iterator_type_info.template_arguments.size(), 1);
     EXPECT_EQ(r[0].iterator_type_info.template_arguments[0].type_name, "Jet_v1");
 
-    EXPECT_EQ(r[0].type_info.nickname, "DataVector<xAOD::Jet_v1>");
+    EXPECT_EQ(r[0].type_info.cpp_name, "DataVector<xAOD::Jet_v1>");
     
     EXPECT_EQ(r[0].link_libraries.size(), 1);
     EXPECT_EQ(r[0].link_libraries[0], "xAODJet");
@@ -69,7 +69,7 @@ TEST(t_xaod_helpers, normal_met_collection) {
     EXPECT_EQ(r[0].iterator_type_info.template_arguments.size(), 1);
     EXPECT_EQ(r[0].iterator_type_info.template_arguments[0].type_name, "MissingET_v1");
 
-    EXPECT_EQ(r[0].type_info.nickname, "xAOD::MissingETContainer_v1");
+    EXPECT_EQ(r[0].type_info.cpp_name, "xAOD::MissingETContainer_v1");
 
     EXPECT_EQ(r[0].link_libraries.size(), 1);
     EXPECT_EQ(r[0].link_libraries[0], "xAODMissingET");


### PR DESCRIPTION
This was mostly meant as a technical debt PR. However, cleanup exposed a few bugs!

* Replace instances of `nickname` with `cpp_name` for clarity and consistency.
* Make `cpp_typename` the actaul fully parsed and rendered typename (so `const int` and `int const` are treated as the same).
* BUG: Address a bug related to the emission of const for constant pointers.
* Remove `typename` and just use `cpp_typename`
* BUG: Address multiple pointers - like `int **`, including when there is a `const` in there.
* BUG/Feature: Workaround ROOT's issues with internal gcc class iterator types and generting odd error messages.

## Notes:

* The "&" is now explicitly ignored everywhere, even in the nickname. This could have knockon effects that aren't seen until code is compiled. e.g. something we aren't testing for. This is as a warning if we have to come back in 6 months to figure out what went wrong.
* This also changed how some of the containers are declared, slightly. So curious to see what happens downstream. Should not affect!