### PR TITLE
Support type generation in Release 25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20.0)
 project(func_adl_types_atlas VERSION 0.1.0)
 
 find_package(ROOT REQUIRED COMPONENTS Core)
@@ -7,11 +7,11 @@ find_package(ROOT REQUIRED COMPONENTS Core)
 string(REPLACE "." ";" AnalysisBase_VERSION_LIST $ENV{AnalysisBase_VERSION})
 list(GET AnalysisBase_VERSION_LIST 0 AnalysisBase_MAJOR_VERSION)
 
+  include(FetchContent)
 if (AnalysisBase_MAJOR_VERSION GREATER_EQUAL 25)
     # FetchContent for version 25 or larger
 
     # Google test
-    include(FetchContent)
     FetchContent_Declare(
       googletest
       URL https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip
@@ -20,7 +20,6 @@ if (AnalysisBase_MAJOR_VERSION GREATER_EQUAL 25)
     FetchContent_MakeAvailable(googletest)
 
     # YAML parsing
-    include(FetchContent)
     FetchContent_Declare(
       yaml-cpp
       URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
@@ -32,7 +31,6 @@ else()
     # FetchContent for version less than 25
 
     # Google test
-    include(FetchContent)
     FetchContent_Declare(
       googletest
       URL https://github.com/google/googletest/archive/release-1.8.1.zip
@@ -40,7 +38,6 @@ else()
     FetchContent_MakeAvailable(googletest)
 
     # YAML parsing
-    include(FetchContent)
     FetchContent_Declare(
       yaml-cpp
       URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
@@ -51,9 +48,15 @@ else()
     find_package(Boost COMPONENTS program_options REQUIRED)
 endif()
 
+# Add argparse
+FetchContent_Declare(
+  argparse
+  URL https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.zip
+)
+FetchContent_MakeAvailable(argparse)
+
 include(CTest)
 enable_testing()
-
 
 # Package setup
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -93,8 +96,7 @@ gtest_discover_tests(t_metadata_file_finder)
 
 # Executables for running the translation
 add_executable(generate_types bin/generate_types.cpp)
-# target_link_libraries(generate_types ROOT::Core wraper_generators Boost::program_options stdc++fs)
-target_link_libraries(generate_types ROOT::Core wraper_generators stdc++fs)
+target_link_libraries(generate_types ROOT::Core wraper_generators argparse stdc++fs)
 
 # # Some definitions for CPACK (incase we need those eventually)
 # set(CPACK_PROJECT_NAME ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,6 @@ FetchContent_Package(googletest https://github.com/google/googletest/archive/075
 FetchContent_Package(yaml-cpp https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip)
 FetchContent_Package(argparse https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.zip)
 
-include(CTest)
-enable_testing()
-
 if($ENV{AnalysisBase_VERSION} VERSION_LESS "25.0.0")
   find_package(Boost COMPONENTS program_options REQUIRED)
 endif()
@@ -49,19 +46,24 @@ add_library(wraper_generators
             src/metadata_file_finder.cpp
             src/translate.cpp
             )
-target_link_libraries(wraper_generators ROOT::Core yaml-cpp stdc++fs)
+target_link_libraries(wraper_generators ROOT::Core yaml-cpp)
+
+# Executables for running the translation
+add_executable(generate_types bin/generate_types.cpp)
+target_link_libraries(generate_types ROOT::Core wraper_generators argparse stdc++fs)
 
 # Tests
+enable_testing()
 add_executable(t_type_helpers tests/t_type_helpers.cpp)
-target_link_libraries(t_type_helpers wraper_generators gtest_main stdc++fs)
+target_link_libraries(t_type_helpers wraper_generators GTest::gtest_main)
 add_executable(t_xaod_helpers tests/t_xaod_helpers.cpp)
-target_link_libraries(t_xaod_helpers wraper_generators gtest_main stdc++fs)
+target_link_libraries(t_xaod_helpers wraper_generators GTest::gtest_main)
 add_executable(t_class_info tests/t_class_info.cpp)
-target_link_libraries(t_class_info wraper_generators gtest_main stdc++fs)
+target_link_libraries(t_class_info wraper_generators GTest::gtest_main)
 add_executable(t_translate tests/t_translate.cpp)
-target_link_libraries(t_translate wraper_generators gtest_main stdc++fs)
+target_link_libraries(t_translate wraper_generators GTest::gtest_main)
 add_executable(t_metadata_file_finder tests/t_metadata_file_finder.cpp)
-target_link_libraries(t_metadata_file_finder wraper_generators gtest_main stdc++fs)
+target_link_libraries(t_metadata_file_finder wraper_generators GTest::gtest_main stdc++fs)
 
 include(GoogleTest)
 gtest_discover_tests(t_type_helpers)
@@ -69,12 +71,3 @@ gtest_discover_tests(t_xaod_helpers)
 gtest_discover_tests(t_class_info)
 gtest_discover_tests(t_translate)
 gtest_discover_tests(t_metadata_file_finder)
-
-# Executables for running the translation
-add_executable(generate_types bin/generate_types.cpp)
-target_link_libraries(generate_types ROOT::Core wraper_generators argparse stdc++fs)
-
-# # Some definitions for CPACK (incase we need those eventually)
-# set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-# set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-# include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,60 +3,36 @@ project(func_adl_types_atlas VERSION 0.1.0)
 
 find_package(ROOT REQUIRED COMPONENTS Core)
 
-# Get the major version number from AnalysisBase_VERSION
-string(REPLACE "." ";" AnalysisBase_VERSION_LIST $ENV{AnalysisBase_VERSION})
-list(GET AnalysisBase_VERSION_LIST 0 AnalysisBase_MAJOR_VERSION)
-
-  include(FetchContent)
-if (AnalysisBase_MAJOR_VERSION GREATER_EQUAL 25)
-    # FetchContent for version 25 or larger
-
-    # Google test
+# Define a macro to handle FetchContent_Declare with conditional DOWNLOAD_EXTRACT_TIMESTAMP
+# This allows us to work with several versions of cmake.
+include(FetchContent)
+macro(FetchContent_Package name url)
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
     FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip
+      ${name}
+      URL ${url}
       DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
-    FetchContent_MakeAvailable(googletest)
-
-    # YAML parsing
+  else()
     FetchContent_Declare(
-      yaml-cpp
-      URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      ${name}
+      URL ${url}
     )
-    FetchContent_MakeAvailable(yaml-cpp)
+  endif()
+  FetchContent_MakeAvailable(${name})
+endmacro()
 
-else()
-    # FetchContent for version less than 25
-
-    # Google test
-    FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/archive/release-1.8.1.zip
-    )
-    FetchContent_MakeAvailable(googletest)
-
-    # YAML parsing
-    FetchContent_Declare(
-      yaml-cpp
-      URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
-    )
-    FetchContent_MakeAvailable(yaml-cpp)
-
-    # Boost
-    find_package(Boost COMPONENTS program_options REQUIRED)
-endif()
-
-# Add argparse
-FetchContent_Declare(
-  argparse
-  URL https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.zip
-)
-FetchContent_MakeAvailable(argparse)
+# Fetch our libraries
+FetchContent_Package(googletest https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip)
+FetchContent_Package(yaml-cpp https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip)
+FetchContent_Package(argparse https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.zip)
 
 include(CTest)
 enable_testing()
+
+if($ENV{AnalysisBase_VERSION} VERSION_LESS "25.0.0")
+  find_package(Boost COMPONENTS program_options REQUIRED)
+endif()
 
 # Package setup
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endmacro()
 
 # Fetch our libraries
 FetchContent_Package(googletest https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip)
-FetchContent_Package(yaml-cpp https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip)
+FetchContent_Package(yaml-cpp https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.zip)
 FetchContent_Package(argparse https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.zip)
 
 if($ENV{AnalysisBase_VERSION} VERSION_LESS "25.0.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if (AnalysisBase_MAJOR_VERSION GREATER_EQUAL 25)
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
     FetchContent_MakeAvailable(yaml-cpp)
+
 else()
     # FetchContent for version less than 25
 
@@ -45,53 +46,55 @@ else()
       URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
     )
     FetchContent_MakeAvailable(yaml-cpp)
+
+    # Boost
+    find_package(Boost COMPONENTS program_options REQUIRED)
 endif()
 
 include(CTest)
 enable_testing()
 
-# # Boost
-# find_package(Boost COMPONENTS program_options REQUIRED)
 
-# # Package setup
-# include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+# Package setup
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# # One main library
-# add_library(wraper_generators
-#             src/normalize.cpp
-#             src/class_info.cpp
-#             src/type_helpers.cpp
-#             src/utils.cpp
-#             src/util_string.cpp
-#             src/xaod_helpers.cpp
-#             src/helper_files.cpp
-#             src/metadata_file_finder.cpp
-#             src/translate.cpp
-#             )
-# target_link_libraries(wraper_generators ROOT::Core yaml-cpp stdc++fs)
+# One main library
+add_library(wraper_generators
+            src/normalize.cpp
+            src/class_info.cpp
+            src/type_helpers.cpp
+            src/utils.cpp
+            src/util_string.cpp
+            src/xaod_helpers.cpp
+            src/helper_files.cpp
+            src/metadata_file_finder.cpp
+            src/translate.cpp
+            )
+target_link_libraries(wraper_generators ROOT::Core yaml-cpp stdc++fs)
 
-# # Tests
-# add_executable(t_type_helpers tests/t_type_helpers.cpp)
-# target_link_libraries(t_type_helpers wraper_generators gtest_main stdc++fs)
-# add_executable(t_xaod_helpers tests/t_xaod_helpers.cpp)
-# target_link_libraries(t_xaod_helpers wraper_generators gtest_main stdc++fs)
-# add_executable(t_class_info tests/t_class_info.cpp)
-# target_link_libraries(t_class_info wraper_generators gtest_main stdc++fs)
-# add_executable(t_translate tests/t_translate.cpp)
-# target_link_libraries(t_translate wraper_generators gtest_main stdc++fs)
-# add_executable(t_metadata_file_finder tests/t_metadata_file_finder.cpp)
-# target_link_libraries(t_metadata_file_finder wraper_generators gtest_main stdc++fs)
+# Tests
+add_executable(t_type_helpers tests/t_type_helpers.cpp)
+target_link_libraries(t_type_helpers wraper_generators gtest_main stdc++fs)
+add_executable(t_xaod_helpers tests/t_xaod_helpers.cpp)
+target_link_libraries(t_xaod_helpers wraper_generators gtest_main stdc++fs)
+add_executable(t_class_info tests/t_class_info.cpp)
+target_link_libraries(t_class_info wraper_generators gtest_main stdc++fs)
+add_executable(t_translate tests/t_translate.cpp)
+target_link_libraries(t_translate wraper_generators gtest_main stdc++fs)
+add_executable(t_metadata_file_finder tests/t_metadata_file_finder.cpp)
+target_link_libraries(t_metadata_file_finder wraper_generators gtest_main stdc++fs)
 
-# include(GoogleTest)
-# gtest_discover_tests(t_type_helpers)
-# gtest_discover_tests(t_xaod_helpers)
-# gtest_discover_tests(t_class_info)
-# gtest_discover_tests(t_translate)
-# gtest_discover_tests(t_metadata_file_finder)
+include(GoogleTest)
+gtest_discover_tests(t_type_helpers)
+gtest_discover_tests(t_xaod_helpers)
+gtest_discover_tests(t_class_info)
+gtest_discover_tests(t_translate)
+gtest_discover_tests(t_metadata_file_finder)
 
-# # Executables for running the translation
-# add_executable(generate_types bin/generate_types.cpp)
+# Executables for running the translation
+add_executable(generate_types bin/generate_types.cpp)
 # target_link_libraries(generate_types ROOT::Core wraper_generators Boost::program_options stdc++fs)
+target_link_libraries(generate_types ROOT::Core wraper_generators stdc++fs)
 
 # # Some definitions for CPACK (incase we need those eventually)
 # set(CPACK_PROJECT_NAME ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,71 +3,97 @@ project(func_adl_types_atlas VERSION 0.1.0)
 
 find_package(ROOT REQUIRED COMPONENTS Core)
 
-# Get Google Test
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip
-#  DOWNLOAD_EXTRACT_TIMESTAMP TRUE - Needed to suppress warning in R21
-)
-FetchContent_MakeAvailable(googletest)
+# Get the major version number from AnalysisBase_VERSION
+string(REPLACE "." ";" AnalysisBase_VERSION_LIST $ENV{AnalysisBase_VERSION})
+list(GET AnalysisBase_VERSION_LIST 0 AnalysisBase_MAJOR_VERSION)
+
+if (AnalysisBase_MAJOR_VERSION GREATER_EQUAL 25)
+    # FetchContent for version 25 or larger
+
+    # Google test
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/075810f7a20405ea09a93f68847d6e963212fa62.zip
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(googletest)
+
+    # YAML parsing
+    include(FetchContent)
+    FetchContent_Declare(
+      yaml-cpp
+      URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(yaml-cpp)
+else()
+    # FetchContent for version less than 25
+
+    # Google test
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/release-1.8.1.zip
+    )
+    FetchContent_MakeAvailable(googletest)
+
+    # YAML parsing
+    include(FetchContent)
+    FetchContent_Declare(
+      yaml-cpp
+      URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
+    )
+    FetchContent_MakeAvailable(yaml-cpp)
+endif()
 
 include(CTest)
 enable_testing()
 
-# YAML parsing
-include(FetchContent)
-FetchContent_Declare(
-  yaml-cpp
-  URL https://github.com/jbeder/yaml-cpp/archive/0579ae3d976091d7d664aa9d2527e0d0cff25763.zip
-#  DOWNLOAD_EXTRACT_TIMESTAMP TRUE - Needed to suppress arning in R22
-)
-FetchContent_MakeAvailable(yaml-cpp)
+# # Boost
+# find_package(Boost COMPONENTS program_options REQUIRED)
 
-# Boost
-find_package(Boost COMPONENTS program_options REQUIRED)
+# # Package setup
+# include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# Package setup
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+# # One main library
+# add_library(wraper_generators
+#             src/normalize.cpp
+#             src/class_info.cpp
+#             src/type_helpers.cpp
+#             src/utils.cpp
+#             src/util_string.cpp
+#             src/xaod_helpers.cpp
+#             src/helper_files.cpp
+#             src/metadata_file_finder.cpp
+#             src/translate.cpp
+#             )
+# target_link_libraries(wraper_generators ROOT::Core yaml-cpp stdc++fs)
 
-# One main library
-add_library(wraper_generators
-            src/normalize.cpp
-            src/class_info.cpp
-            src/type_helpers.cpp
-            src/utils.cpp
-            src/util_string.cpp
-            src/xaod_helpers.cpp
-            src/helper_files.cpp
-            src/metadata_file_finder.cpp
-            src/translate.cpp
-            )
-target_link_libraries(wraper_generators ROOT::Core yaml-cpp stdc++fs)
+# # Tests
+# add_executable(t_type_helpers tests/t_type_helpers.cpp)
+# target_link_libraries(t_type_helpers wraper_generators gtest_main stdc++fs)
+# add_executable(t_xaod_helpers tests/t_xaod_helpers.cpp)
+# target_link_libraries(t_xaod_helpers wraper_generators gtest_main stdc++fs)
+# add_executable(t_class_info tests/t_class_info.cpp)
+# target_link_libraries(t_class_info wraper_generators gtest_main stdc++fs)
+# add_executable(t_translate tests/t_translate.cpp)
+# target_link_libraries(t_translate wraper_generators gtest_main stdc++fs)
+# add_executable(t_metadata_file_finder tests/t_metadata_file_finder.cpp)
+# target_link_libraries(t_metadata_file_finder wraper_generators gtest_main stdc++fs)
 
-# Tests
-add_executable(t_type_helpers tests/t_type_helpers.cpp)
-target_link_libraries(t_type_helpers wraper_generators gtest_main stdc++fs)
-add_executable(t_xaod_helpers tests/t_xaod_helpers.cpp)
-target_link_libraries(t_xaod_helpers wraper_generators gtest_main stdc++fs)
-add_executable(t_class_info tests/t_class_info.cpp)
-target_link_libraries(t_class_info wraper_generators gtest_main stdc++fs)
-add_executable(t_translate tests/t_translate.cpp)
-target_link_libraries(t_translate wraper_generators gtest_main stdc++fs)
-add_executable(t_metadata_file_finder tests/t_metadata_file_finder.cpp)
-target_link_libraries(t_metadata_file_finder wraper_generators gtest_main stdc++fs)
+# include(GoogleTest)
+# gtest_discover_tests(t_type_helpers)
+# gtest_discover_tests(t_xaod_helpers)
+# gtest_discover_tests(t_class_info)
+# gtest_discover_tests(t_translate)
+# gtest_discover_tests(t_metadata_file_finder)
 
-include(GoogleTest)
-gtest_discover_tests(t_type_helpers)
-gtest_discover_tests(t_xaod_helpers)
-gtest_discover_tests(t_class_info)
-gtest_discover_tests(t_translate)
-gtest_discover_tests(t_metadata_file_finder)
+# # Executables for running the translation
+# add_executable(generate_types bin/generate_types.cpp)
+# target_link_libraries(generate_types ROOT::Core wraper_generators Boost::program_options stdc++fs)
 
-# Executables for running the translation
-add_executable(generate_types bin/generate_types.cpp)
-target_link_libraries(generate_types ROOT::Core wraper_generators Boost::program_options stdc++fs)
-
-# Some definitions for CPACK (incase we need those eventually)
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
+# # Some definitions for CPACK (incase we need those eventually)
+# set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+# set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
+# include(CPack)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the development container
 
-FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.12
 # 21.2.184 - for R21
 # 22.2.113 - for R22
 # 25.2.12 - for R25

--- a/scripts/run_on_atlas_containers.sh
+++ b/scripts/run_on_atlas_containers.sh
@@ -1,5 +1,5 @@
 containers=$(find -L $ROOTCOREDIR/include -name \*Container.h -exec basename {} \; | sed 's/..$//' | sed 's/^/-c xAOD::/')
 libraries=$(find -L $ROOTCOREDIR/lib -name \*.so -exec basename {} \; | grep -vi Dict | grep xAOD | sed 's/...$//' | sed 's/^/-l /')
-required_classes=$(sed 's/^/--c "/; s/$/"/' scripts/required_classes.txt | tr '\n' ' ')
+required_classes=$(sed 's/^/-c "/; s/$/"/' scripts/required_classes.txt | tr '\n' ' ')
 
 eval ./build/generate_types $containers $libraries $required_classes


### PR DESCRIPTION
* Replace the command line parsing with the library `argparse` - the boost command line parser was being used, but R25 no longer has boost.
   * Required a small change in how command line arguments are getting passed.
* Major update to `CMakeLists.txt` to support both old and new `CMake` versions.

Fixes #33