### PR TITLE
Include global enum's

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,7 +66,20 @@
         "thread": "cpp",
         "cfenv": "cpp",
         "cinttypes": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "bit": "cpp",
+        "charconv": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "csignal": "cpp",
+        "source_location": "cpp",
+        "format": "cpp",
+        "numbers": "cpp",
+        "semaphore": "cpp",
+        "shared_mutex": "cpp",
+        "span": "cpp",
+        "stop_token": "cpp",
+        "valarray": "cpp"
     },
     "restructuredtext.languageServer.disabled": true,
     "cSpell.words": [

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -42,7 +42,7 @@ bool can_emit_class(const class_info &c_info) {
             return false;
         }
     }
-    if (c_info.methods.size() == 0) {
+    if (c_info.methods.size() == 0 && c_info.enums.size() == 0) {
         return false;
     }
     return true;
@@ -433,6 +433,8 @@ int main(int argc, char**argv) {
         // If we can dump the class, then we should!
         if (can_emit_class(c_info->second)) {
             classes_to_emit.insert(c_info->first);
+        } else {
+            cerr << "ERROR: Class " << c_name << " fails `can_emit_class`: not emitted." << endl;
         }
 
         // Now, add referenced classes to the queue
@@ -480,15 +482,12 @@ int main(int argc, char**argv) {
             auto class_info_ptr = class_map.find(c_name);
             if (class_info_ptr != class_map.end()) {
                 auto &&class_info = class_info_ptr->second;
-                if (!can_emit_any_methods(class_info.methods, known_types)) {
-                    bad_classes.insert(c_name);
-                    cerr << "ERROR: Class " << c_name << " not translated: no methods to emit." << endl;
-                }
                 if (!check_template_arguments(class_info.name_as_type, known_types)) {
                     bad_classes.insert(c_name);
                     cerr << "ERROR: Class " << c_name << " not translated: template arguments were bad." << endl;
                 }
                 if (!is_root_only_class(class_info)) {
+                    cerr << "INFO: Class " << c_name << " not translated: ROOT only class." << endl;
                     bad_classes.insert(c_name);
                 }
             }

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -621,12 +621,7 @@ int main(int argc, char**argv) {
         // Find the class
         auto c_info = class_map.find(c_name);
         if (c_info == class_map.end()) {
-            continue;
-        }
-
-        // Make sure there is at least one method
-        // TODO: this is not needed, delete and check.
-        if (!can_emit_any_methods(c_info->second.methods, known_types)) {
+            cerr << "ERROR: Ready to emit class " << c_name << " but it is not in the class map." << endl;
             continue;
         }
 

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -298,7 +298,6 @@ int main(int argc, char**argv) {
                 continue;
             }
         classes_done.insert(class_name);
-        cout << "--> Translating class " << raw_class_name << " (" << classes_to_do.size() << " classes left)" << endl;
 
         // Translate the class
         auto c = translate_class(class_name);
@@ -319,7 +318,6 @@ int main(int argc, char**argv) {
                 // Make sure it isn't on the classes_to_do list or the classes_done list first
                 if (classes_done.find(namespace_stem) == classes_done.end()
                     && seen_namespace_additions.find(namespace_stem) == seen_namespace_additions.end()) {
-                    cout << "--> adding namespace " << namespace_stem << endl;
                     classes_to_do.push(namespace_stem);
                     seen_namespace_additions.insert(namespace_stem);
                 }

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -692,7 +692,7 @@ int main(int argc, char**argv) {
                 // Do not warn when return type is void - this is just how we work
                 // in a functional world for now (e.g. by design).
                 if (meth.return_type.size() != 0) {
-                    cerr << "ERROR: Cannot emit method " << c_info->first << "::" << meth.name << " - some types not emitted: ";
+                    cerr << "ERROR: Cannot emit method " << c_info->first << "::" << meth.name << " - some types not known: ";
                     for (const auto& arg : method_args) {
                         cerr << arg << ", ";
                     }

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -209,8 +209,43 @@ bool load_template_arguments(const vector<typename_info> &types) {
     // load their template arguments first.
     // Gets around ROOT failing to load ElementLink<xAOD::MuonContainer>
     // even though it knows about all of that.
+
+    // Some base types that aren't classes but are well known.
+    static set<string> base_types;
+    if (base_types.size() == 0) {
+        base_types.insert("int");
+        base_types.insert("float");
+        base_types.insert("double");
+        base_types.insert("bool");
+        base_types.insert("string");
+        base_types.insert("char");
+        base_types.insert("unsigned char");
+        base_types.insert("signed char");
+        base_types.insert("short");
+        base_types.insert("unsigned short");
+        base_types.insert("unsigned int");
+        base_types.insert("long");
+        base_types.insert("unsigned long");
+        base_types.insert("long long");
+        base_types.insert("unsigned long long");
+        base_types.insert("char16_t");
+        base_types.insert("char32_t");
+        base_types.insert("uint");
+        base_types.insert("uint8_t");
+        base_types.insert("uint16_t");
+        base_types.insert("uint32_t");
+        base_types.insert("uint64_t");
+        base_types.insert("int8_t");
+        base_types.insert("int16_t");
+        base_types.insert("int32_t");
+        base_types.insert("int64_t");
+    }
+
     for (auto &&t : types)
     {
+        if (base_types.find(t.type_name) != base_types.end()) {
+            continue;
+        }
         if (get_tclass(unqualified_typename(t)) == nullptr)
         {
             // If we can't load it, then load template arguments first.


### PR DESCRIPTION
* Enums defined in namespaces are now included in the translation.
* A byproduct of this is classes wth no methods are written out (ROOT treats classes and namespaces as the same thing)

## Minor

* Improve a few error messages
* Limit, a bit, how template arguments are resolved. This significantly speeds things up, but I'm worried we lost a few classes.

Fixes #37