### PR TITLE
Add typedefs

### DIFF
--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -455,8 +455,10 @@ int main(int argc, char**argv) {
     classes_to_emit.insert("int8_t");
     classes_to_emit.insert("int16_t");
     classes_to_emit.insert("int32_t");
+    classes_to_emit.insert("int64_t");
     classes_to_emit.insert("uint8_t");
     classes_to_emit.insert("uint16_t");
+    classes_to_emit.insert("uint64_t");
     classes_to_emit.insert("uint");
     classes_to_emit.insert("unsigned int");
     classes_to_emit.insert("char");

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -620,6 +620,7 @@ int main(int argc, char**argv) {
         << YAML::BeginSeq;
 
     // Get a list of a list of all classes 
+    map<string, vector<string>> failed_types;
     for (auto &&c : classes_to_emit)
     {
         string c_name(unqualified_type_name(c));
@@ -726,6 +727,7 @@ int main(int argc, char**argv) {
                             }
                             first = false;
                             cerr << arg;
+                            failed_types[arg].push_back(c_info->first + "::" + meth.name);
                         }
                     }
                     cerr << endl;
@@ -736,7 +738,6 @@ int main(int argc, char**argv) {
         if (!first_method) {
             out << YAML::EndSeq;
         }
-        
 
         out << YAML::EndMap;
     }
@@ -776,4 +777,17 @@ int main(int argc, char**argv) {
         metadata_in.read(&buf[0], buf_size);
         cout.write(&buf[0], metadata_in.gcount());
     } while (metadata_in.gcount() > 0);     
+
+    // Dump the failed types and their associated methods
+    cerr << "Summary of failed types and their methods:" << endl;
+    vector<pair<string, vector<string>>> sorted_failed_types(failed_types.begin(), failed_types.end());
+    sort(sorted_failed_types.begin(), sorted_failed_types.end(), [](const auto& a, const auto& b) {
+        return a.second.size() > b.second.size();
+    });
+    for (const auto& [type, methods] : sorted_failed_types) {
+        cerr << "Type: " << type << ", Number of methods: " << methods.size() << endl;
+        for (const auto& method : methods) {
+            cerr << "  " << method << endl;
+        }
+    }
 }

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -452,8 +452,16 @@ int main(int argc, char**argv) {
     classes_to_emit.insert("short");
     classes_to_emit.insert("unsigned short");
     classes_to_emit.insert("int");
-    classes_to_emit.insert("size_t");
+    classes_to_emit.insert("int8_t");
+    classes_to_emit.insert("int16_t");
+    classes_to_emit.insert("int32_t");
+    classes_to_emit.insert("uint8_t");
+    classes_to_emit.insert("uint16_t");
+    classes_to_emit.insert("uint");
     classes_to_emit.insert("unsigned int");
+    classes_to_emit.insert("char");
+    classes_to_emit.insert("unsigned char");
+    classes_to_emit.insert("size_t");
     classes_to_emit.insert("long");
     classes_to_emit.insert("unsigned long");
     classes_to_emit.insert("long long");
@@ -709,9 +717,16 @@ int main(int argc, char**argv) {
                 // Do not warn when return type is void - this is just how we work
                 // in a functional world for now (e.g. by design).
                 if (meth.return_type.size() != 0) {
+                    bool first = true;
                     cerr << "ERROR: Cannot emit method " << c_info->first << "::" << meth.name << " - some types not known: ";
                     for (const auto& arg : method_args) {
-                        cerr << arg << ", ";
+                        if (known_types.find(arg) == known_types.end()) {
+                            if (!first) {
+                                cerr << ", ";
+                            }
+                            first = false;
+                            cerr << arg;
+                        }
                     }
                     cerr << endl;
                 }

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -90,6 +90,7 @@ map<string, vector<string>> root_typedef_map()
             typedef_back_map[base_name].push_back(typedef_name);
         }
     }
+
     return typedef_back_map;
 }
 
@@ -116,6 +117,15 @@ void build_typedef_map() {
     // Add a few special ones to keep the system working
     g_typedef_map["ULong64_t"] = "unsigned long long";
     g_typedef_map["uint32_t"] = "unsigned int";
+    g_typedef_map["Double_t"] = "double";
+    g_typedef_map["Float_t"] = "float";
+    g_typedef_map["Int_t"] = "int";
+    g_typedef_map["Long64_t"] = "long long";
+    g_typedef_map["Long_t"] = "long";
+    g_typedef_map["Bool_t"] = "bool";
+    g_typedef_map["UInt_t"] = "unsigned int";
+    g_typedef_map["ULong_t"] = "unsigned long";
+    g_typedef_map["ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>::Scalar"] = "double";
 
     // Some class typedef's that ROOT RTTI can't seem to "get".
     g_typedef_map["xAOD::CaloCluster_v1::CaloSample"] = "CaloSampling::CaloSample";
@@ -136,7 +146,7 @@ string resolve_typedef(const string &c_name) {
     // For whatever reason, ROOT never seems to know about this,
     // and this is a strictly C++ type.
     if (t.type_name == "size_t") {
-        return "int";
+        return "unsigned int";
     }
 
     string result = unqualified_typename(t);

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -380,7 +380,7 @@ TEST(t_type_helpers, typedef_resolve_simple) {
 
 TEST(t_type_helpers, typedef_resolve_size_t) {
     TClass::GetClass("xAOD::EventInfo"); // Make sure the typedefs are loaded into root!
-    EXPECT_EQ(resolve_typedef("size_t"), "int");
+    EXPECT_EQ(resolve_typedef("size_t"), "unsigned int");
 }
 
 TEST(t_type_helpers, typedef_resolve_blank) {


### PR DESCRIPTION
* Add base types (like char, unit8_t, etc.)
* Add typedefs that ROOT seems to keep missing in its type system, like `Double_t`
* Add nice dump at end of log file which lets you see which types have the most number of methods they prevent being emitted.

Fixes #39