### PR TITLE
Support 25.2.42

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the development container
 
-FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.12
+FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42
 # 21.2.184 - for R21
 # 22.2.113 - for R22
 # 25.2.12 - for R25

--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -143,8 +143,12 @@ string extract_container_iterator_type(const collection_info &c)
 }
 
 // These classes are known to be problematic
-set<string> _g_bad_classes {
-    "ROOT", "SG", "xAOD", "TObject", "SG::auxid_set_t"
+set<string> _g_bad_classes{
+    "ROOT",
+    "SG",
+    "TObject",
+    "SG::auxid_set_t",
+    "DataModel_detail",
 };
 
 // Inspect the class name. There are just some classes we
@@ -153,6 +157,7 @@ bool class_name_is_good(const string &c_name) {
     return (_g_bad_classes.find(c_name) == _g_bad_classes.end()
         && (c_name.find("Eigen") == c_name.npos)
         && (c_name.find("SG::") == c_name.npos)
+        && (c_name.find("ROOT::Experimental") != 0)
        );
 }
 

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -274,6 +274,7 @@ class_info translate_class(const std::string &class_name)
 
     // Get the class
     auto unq_class_name = unqualified_typename(t_prior);
+    cout << "--> Translating class: " << unq_class_name << "(" << class_name << ")" << endl;
     auto c_info = get_tclass(unq_class_name);
     if (c_info == nullptr)
     {

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -274,7 +274,6 @@ class_info translate_class(const std::string &class_name)
 
     // Get the class
     auto unq_class_name = unqualified_typename(t_prior);
-    cout << "--> Translating class: " << unq_class_name << "(" << class_name << ")" << endl;
     auto c_info = get_tclass(unq_class_name);
     if (c_info == nullptr)
     {


### PR DESCRIPTION
* Everything that is ROOT::Experimental blocked
* DataModel_detial namespace (only) blocked.

Both of these are causing ROOT to crash during the `TClass::GetClass`. It looks like a root bug. 

Make sure this works with 25.2.42 
Fixes #42