### PR TITLE
`unsigned char` in a template argument

### DIFF
--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -418,6 +418,7 @@ string normalized_type_name(const typename_info &ti)
             }
             break;
 
+        case ' ':
         case ',':
             result[i] = '_';
             break;

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -698,7 +698,13 @@ TEST(t_type_helpers, normalized_vector_front_ns) {
     EXPECT_EQ(normalized_type_name("std::vector<double>"), "std.vector_float_");
 }
 
-TEST(t_type_helpers, normalized_elPtr) {
+TEST(t_type_helpers, normalized_vector_space)
+{
+    EXPECT_EQ(normalized_type_name("vector<unsigned char>"), "vector_unsigned_char_");
+}
+
+TEST(t_type_helpers, normalized_elPtr)
+{
     EXPECT_EQ(normalized_type_name("ElementLink<DataVector<xAOD::Truth>>"), "ElementLink_DataVector_xAOD_Truth__");
 }
 


### PR DESCRIPTION
* Fix python type name bug - make sure unsigned char - or any space - is handled correctly.

Fixes #44