### PR TITLE
Correct python container types

### DIFF
--- a/src/class_info.cpp
+++ b/src/class_info.cpp
@@ -70,6 +70,17 @@ map<string, string> python_type_conversions =
         {"unsigned long long", "int"},
         {"size_t", "int"},
         {"string", "str"},
+        {"unsigned char", "int"},
+        {"char", "int"},
+        {"int8_t", "int"},
+        {"int16_t", "int"},
+        {"int32_t", "int"},
+        {"int64_t", "int"},
+        {"uint8_t", "int"},
+        {"uint16_t", "int"},
+        {"uint32_t", "int"},
+        {"uint64_t", "int"},
+        {"uint", "int"},
     };
 
 // Reconstruct the full type name

--- a/tests/t_class_info.cpp
+++ b/tests/t_class_info.cpp
@@ -122,7 +122,16 @@ TEST(t_class_info, convert_double_to_float) {
     EXPECT_EQ(out.str(), "vector[float]");
 }
 
-TEST(t_class_info, has_methods_no) {
+TEST(t_class_info, convert_unsigned_char)
+{
+    auto tn = parse_typename("vector<unsigned char>");
+    ostringstream out;
+    out << tn;
+    EXPECT_EQ(out.str(), "vector[int]");
+}
+
+TEST(t_class_info, has_methods_no)
+{
     method_info mi;
     mi.name = "begin";
 


### PR DESCRIPTION
* `is_container_of_python` how correctly converts 'unsigned int' to `int`.

Fixes #48