### PR TITLE
Remove redundant typedef resolution

### DIFF
--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -73,27 +73,6 @@ vector<string> all_that_inherit_from(const string &c_name)
     return vector<string>(results.begin(), results.end());
 }
 
-// Build a list of type mapping
-map<string, vector<string>> root_typedef_map()
-{
-    // Build a typedef backwards mapping
-	TIter i_typedef (gROOT->GetListOfTypes(true));
-	int junk = gROOT->GetListOfTypes()->GetEntries();
-	TDataType *typedef_spec;
-    map<string, vector<string>> typedef_back_map;
-	while ((typedef_spec = static_cast<TDataType*>(i_typedef.Next())) != 0)
-	{
-		string typedef_name = typedef_spec->GetName();
-		string base_name = typedef_spec->GetFullTypeName();
-
-        if (typedef_name != base_name) {
-            typedef_back_map[base_name].push_back(typedef_name);
-        }
-    }
-
-    return typedef_back_map;
-}
-
 map<string, string> g_typedef_map;
 
 void build_typedef_map() {
@@ -130,6 +109,22 @@ void build_typedef_map() {
     // Some class typedef's that ROOT RTTI can't seem to "get".
     g_typedef_map["xAOD::CaloCluster_v1::CaloSample"] = "CaloSampling::CaloSample";
     g_typedef_map["xAOD::CaloCluster_v1::flt_t"] = "float";
+}
+
+// Build a list of type mapping
+map<string, vector<string>> root_typedef_map()
+{
+    // Build the forward map
+    build_typedef_map();
+
+    // Use that to build the backwards map.
+    map<string, vector<string>> typedef_back_map;
+    for (auto &item : g_typedef_map)
+    {
+        typedef_back_map[item.second].push_back(item.first);
+    }
+
+    return typedef_back_map;
 }
 
 // From typedefs, return resolved typedefs.

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -700,7 +700,7 @@ TEST(t_type_helpers, normalized_vector_front_ns) {
 
 TEST(t_type_helpers, normalized_vector_space)
 {
-    EXPECT_EQ(normalized_type_name("vector<unsigned char>"), "vector_unsigned_char_");
+    EXPECT_EQ(normalized_type_name("vector<unsigned char>"), "vector_int_");
 }
 
 TEST(t_type_helpers, normalized_elPtr)


### PR DESCRIPTION
* The typedef table bult from ROOT's typedef was duplicated.
* Now runs once, and everything is derived from that one run.
* Makes typedefs more consitent (particularly the additonal by-hand ones).

No expected changes to results.

Fixes #40