### PR TITLE
Cull emitted classes and remove basic types

### DIFF
--- a/bin/generate_types.cpp
+++ b/bin/generate_types.cpp
@@ -639,6 +639,11 @@ int main(int argc, char**argv) {
             continue;
         }
 
+        if (!can_emit_class(c_info->second)) {
+            cerr << "ERROR: Ready to emit class " << c_name << " but it is on our list of classes to block." << endl;
+            continue;
+        }
+
         // If we can dump the class, then we should!
         out << YAML::BeginMap
             << YAML::Key << "python_name" << YAML::Value << normalized_type_name(c_info->second.name_as_type)


### PR DESCRIPTION
* We were emitting `std::string` as a full blown class with methods. Prevent that.
* We now do not emit any class that is on the "don't emit" list.

Fixes #9