### PR TITLE
Fixed problems with Vector C++ Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ test1.txt
 test1.yaml
 test.yaml
 Testing/
+
+.DS_Store

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -521,12 +521,6 @@ std::string unqualified_typename(const typename_info &ti)
     return typename_cpp_string(n_ti);
 }
 
-set<string> _known_templates({
-    "vector",
-    // "ElementLink",
-    // "DataVector",
-});
-
 // Return the C++ type in a standard format
 std::string typename_cpp_string(const typename_info &ti)
 {
@@ -547,7 +541,7 @@ std::string typename_cpp_string(const typename_info &ti)
     if (!first)
         stream << "::";
 
-    if (first && _known_templates.count(ti.type_name))
+    if (first && is_collection(ti))
         stream << "std::";
     
     stream << ti.type_name;

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -521,6 +521,12 @@ std::string unqualified_typename(const typename_info &ti)
     return typename_cpp_string(n_ti);
 }
 
+set<string> _known_templates({
+    "vector",
+    // "ElementLink",
+    // "DataVector",
+});
+
 // Return the C++ type in a standard format
 std::string typename_cpp_string(const typename_info &ti)
 {
@@ -541,7 +547,11 @@ std::string typename_cpp_string(const typename_info &ti)
     if (!first)
         stream << "::";
 
+    if (first && _known_templates.count(ti.type_name))
+        stream << "std::";
+    
     stream << ti.type_name;
+
 
     // And any template arguments
     first = true;
@@ -569,12 +579,6 @@ std::string typename_cpp_string(const typename_info &ti)
 
     return stream.str();
 }
-
-set<string> _known_templates({
-    "vector",
-    // "ElementLink",
-    // "DataVector",
-});
 
 // See if we can handle this type:
 // Raw types in the known list are ok

--- a/src/type_helpers.cpp
+++ b/src/type_helpers.cpp
@@ -273,6 +273,12 @@ typename_info parse_typename(const string &type_name)
                     }
                     else
                     {
+                        if (is_collection(result) && result.namespace_list.empty()) {
+                            typename_info std_ns;
+                            std_ns.type_name = "std";
+                            std_ns.cpp_name = "std";
+                            result.namespace_list.insert(result.namespace_list.begin(), std_ns);
+                        }
                         result.cpp_name = typename_cpp_string(result);
                         typename_info nested_ns = result;
                         result = typename_info();
@@ -346,6 +352,13 @@ typename_info parse_typename(const string &type_name)
         name = "";
     }
     result.is_const = top_level_is_const;
+
+    if (is_collection(result) && result.namespace_list.empty()) {
+        typename_info std_ns;
+        std_ns.type_name = "std";
+        std_ns.cpp_name = "std";
+        result.namespace_list.insert(result.namespace_list.begin(), std_ns);
+    }
 
     // Get the full type name right, and properly parsed.
     result.cpp_name = typename_cpp_string(result);
@@ -541,9 +554,6 @@ std::string typename_cpp_string(const typename_info &ti)
     if (!first)
         stream << "::";
 
-    if (first && is_collection(ti))
-        stream << "std::";
-    
     stream << ti.type_name;
 
 
@@ -648,6 +658,7 @@ typename_info py_typename(const typename_info &t)
     if (t.type_name == "vector" || t.type_name == "DataVector") {
         typename_info result(t);
         result.type_name = "Iterable";
+        result.namespace_list.clear();
         result.template_arguments[0] = py_typename(t.template_arguments[0]);
         result.cpp_name = typename_cpp_string(result);
         return result;

--- a/tests/t_class_info.cpp
+++ b/tests/t_class_info.cpp
@@ -119,7 +119,7 @@ TEST(t_class_info, convert_double_to_float) {
     auto tn = parse_typename("vector<double>");
     ostringstream out;
     out << tn;
-    EXPECT_EQ(out.str(), "vector[float]");
+    EXPECT_EQ(out.str(), "std.vector[float]");
 }
 
 TEST(t_class_info, convert_unsigned_char)
@@ -127,7 +127,7 @@ TEST(t_class_info, convert_unsigned_char)
     auto tn = parse_typename("vector<unsigned char>");
     ostringstream out;
     out << tn;
-    EXPECT_EQ(out.str(), "vector[int]");
+    EXPECT_EQ(out.str(), "std.vector[int]");
 }
 
 TEST(t_class_info, has_methods_no)

--- a/tests/t_class_info.cpp
+++ b/tests/t_class_info.cpp
@@ -25,7 +25,7 @@ TEST(t_class_info, referenced_class_template_argument) {
     ci.name_as_type = parse_typename(ci.name);
 
     auto ref_list = referenced_types(ci);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"SubClass", "vector<SubClass>"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"SubClass", "std::vector<SubClass>"}));
 }
 
 TEST(t_class_info, referenced_typeinfo_pointer) {
@@ -47,21 +47,21 @@ TEST(t_class_info, referenced_typeinfo_template) {
     auto tn = parse_typename("vector<SubClass>");
 
     auto ref_list = referenced_types(tn);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"SubClass", "vector<SubClass>"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"SubClass", "std::vector<SubClass>"}));
 }
 
 TEST(t_class_info, referenced_typeinfo_template_with_namespace) {
     auto tn = parse_typename("vector<std::SubClass>");
 
     auto ref_list = referenced_types(tn);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"std::SubClass", "vector<std::SubClass>"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"std::SubClass", "std::vector<std::SubClass>"}));
 }
 
 TEST(t_class_info, referenced_typeinfo_qualified_name) {
     auto tn = parse_typename("vector<std::SubClass>::size_t");
 
     auto ref_list = referenced_types(tn);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"vector<std::SubClass>::size_t"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"std::vector<std::SubClass>::size_t"}));
 }
 
 TEST(t_class_info, referenced_element_link) {
@@ -77,7 +77,7 @@ TEST(t_class_info, referenced_method_return_type) {
     mi.return_type = "vector<std::SubClass>";
 
     auto ref_list = referenced_types(mi);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"vector<std::SubClass>", "std::SubClass"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"std::vector<std::SubClass>", "std::SubClass"}));
 }
 
 TEST(t_class_info, referenced_method_args) {
@@ -92,7 +92,7 @@ TEST(t_class_info, referenced_method_args) {
     mi.arguments.push_back(ma);
 
     auto ref_list = referenced_types(mi);
-    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"vector<std::SubClass>", "std::SubClass", "xAOD::Jet"}));
+    EXPECT_EQ(set<string>(ref_list.begin(), ref_list.end()), set<string>({"std::vector<std::SubClass>", "std::SubClass", "xAOD::Jet"}));
 }
 
 TEST(t_class_info, referenced_typename_ignore_integers) {

--- a/tests/t_translate.cpp
+++ b/tests/t_translate.cpp
@@ -78,7 +78,7 @@ TEST(t_translate, truth_particle_methods) {
 TEST(t_translate, vector_float) {
     auto info = translate_class("vector<float>");
 
-    EXPECT_EQ(info.name, "vector<float>");
+    EXPECT_EQ(info.name, "std::vector<float>");
     EXPECT_EQ(info.methods.size(), 1);
     EXPECT_EQ(info.methods[0].name, "size");
     EXPECT_EQ(info.inherited_class_names.size(), 0);

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -211,7 +211,8 @@ TEST(t_type_helpers, type_const_unsigned_int)
 TEST(t_type_helpers, type_vector_int) {
     auto t = parse_typename("vector<int>");
 
-    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.namespace_list.size(), 1);
+    EXPECT_EQ(t.namespace_list[0].type_name, "std");
     EXPECT_EQ(t.template_arguments.size(), 1);
     auto sub_t = t.template_arguments[0];
     EXPECT_EQ(sub_t.type_name, "int");
@@ -274,7 +275,8 @@ TEST(t_type_helpers, type_namespaced_buried) {
 
     EXPECT_EQ(t.type_name, "vector");
 
-    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.namespace_list.size(), 1);
+    EXPECT_EQ(t.namespace_list[0].type_name, "std");
 
     EXPECT_EQ(t.template_arguments.size(), 1);
     auto t_arg1 = t.template_arguments[0];
@@ -316,7 +318,8 @@ TEST(t_type_helpers, type_multiple_template_args) {
 
     EXPECT_EQ(t.type_name, "vector");
 
-    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.namespace_list.size(), 1);
+    EXPECT_EQ(t.namespace_list[0].type_name, "std");
 
     EXPECT_EQ(t.template_arguments.size(), 2);
     EXPECT_EQ(t.template_arguments[0].type_name, "size_t");
@@ -329,7 +332,8 @@ TEST(t_type_helpers, type_multiple_template_args_with_spaces)
 
     EXPECT_EQ(t.type_name, "vector");
 
-    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.namespace_list.size(), 1);
+    EXPECT_EQ(t.namespace_list[0].type_name, "std");
 
     EXPECT_EQ(t.template_arguments.size(), 2);
     EXPECT_EQ(t.template_arguments[0].type_name, "size_t");
@@ -344,7 +348,8 @@ TEST(t_type_helpers, type_multiple_template_args_with_spaces_no_ns)
 
     EXPECT_EQ(t.type_name, "vector");
 
-    EXPECT_EQ(t.namespace_list.size(), 0);
+    EXPECT_EQ(t.namespace_list.size(), 1);
+    EXPECT_EQ(t.namespace_list[0].type_name, "std");
 
     EXPECT_EQ(t.template_arguments.size(), 2);
     EXPECT_EQ(t.template_arguments[0].type_name, "size_t");
@@ -683,7 +688,7 @@ TEST(t_type_helpers, normalized_int) {
 }
 
 TEST(t_type_helpers, normalized_vector) {
-    EXPECT_EQ(normalized_type_name("vector<float>"), "vector_float_");
+    EXPECT_EQ(normalized_type_name("vector<float>"), "std.vector_float_");
 }
 
 TEST(t_type_helpers, normalized_iterable) {
@@ -691,7 +696,7 @@ TEST(t_type_helpers, normalized_iterable) {
 }
 
 TEST(t_type_helpers, normalized_vector_ns) {
-    EXPECT_EQ(normalized_type_name("vector<ROOT::Fit::ParameterSettings>"), "vector_ROOT_Fit_ParameterSettings_");
+    EXPECT_EQ(normalized_type_name("vector<ROOT::Fit::ParameterSettings>"), "std.vector_ROOT_Fit_ParameterSettings_");
 }
 
 TEST(t_type_helpers, normalized_vector_front_ns) {
@@ -700,7 +705,7 @@ TEST(t_type_helpers, normalized_vector_front_ns) {
 
 TEST(t_type_helpers, normalized_vector_space)
 {
-    EXPECT_EQ(normalized_type_name("vector<unsigned char>"), "vector_int_");
+    EXPECT_EQ(normalized_type_name("vector<unsigned char>"), "std.vector_int_");
 }
 
 TEST(t_type_helpers, normalized_elPtr)

--- a/tests/t_type_helpers.cpp
+++ b/tests/t_type_helpers.cpp
@@ -294,11 +294,11 @@ TEST(t_type_helpers, type_namespaced_buried) {
 TEST(t_type_helpers, type_qualified_typename) {
     auto t = parse_typename("vector<float>::size_t");
 
-    EXPECT_EQ(t.cpp_name, "vector<float>::size_t");
+    EXPECT_EQ(t.cpp_name, "std::vector<float>::size_t");
     EXPECT_EQ(t.type_name, "size_t");
     EXPECT_EQ(t.template_arguments.size(), 0);
     EXPECT_EQ(t.namespace_list.size(), 1);
-    EXPECT_EQ(t.namespace_list[0].cpp_name, "vector<float>");
+    EXPECT_EQ(t.namespace_list[0].cpp_name, "std::vector<float>");
 }
 
 
@@ -306,7 +306,7 @@ TEST(t_type_helpers, type_qualified_typename) {
 TEST(t_type_helpers, type_whitespace) {
     auto t = parse_typename("vector<float>::size_t ");
 
-    EXPECT_EQ(t.cpp_name, "vector<float>::size_t");
+    EXPECT_EQ(t.cpp_name, "std::vector<float>::size_t");
 }
 
 
@@ -558,7 +558,7 @@ TEST(t_type_helpers, cpp_string_simple_ns) {
 }
 
 TEST(t_type_helpers, cpp_string_simple_template) {
-    EXPECT_EQ(typename_cpp_string(parse_typename("vector<int>")), "vector<int>");
+    EXPECT_EQ(typename_cpp_string(parse_typename("vector<int>")), "std::vector<int>");
 }
 
 
@@ -567,7 +567,7 @@ TEST(t_type_helpers, cpp_string_simple_multi_ns) {
 }
 
 TEST(t_type_helpers, cpp_string_simple_template_args) {
-    EXPECT_EQ(typename_cpp_string(parse_typename("vector<int, float>")), "vector<int, float>");
+    EXPECT_EQ(typename_cpp_string(parse_typename("vector<int, float>")), "std::vector<int, float>");
 }
 
 TEST(t_type_helpers, unqualified_pointer) {
@@ -579,11 +579,11 @@ TEST(t_type_helpers, unqualified_const) {
 }
 
 TEST(t_type_helpers, unqualified_template_args_untouched) {
-    EXPECT_EQ(unqualified_typename(parse_typename("const vector<int*>")), "vector<int *>");
+    EXPECT_EQ(unqualified_typename(parse_typename("const vector<int*>")), "std::vector<int *>");
 }
 
 TEST(t_type_helpers, unqualified_template_args_untouched_with_const) {
-    EXPECT_EQ(unqualified_typename(parse_typename("vector<const int*>")), "vector<const int *>");
+    EXPECT_EQ(unqualified_typename(parse_typename("vector<const int*>")), "std::vector<const int *>");
 }
 
 TEST(t_type_helpers, unqualified_const_DataVector) {
@@ -599,7 +599,7 @@ TEST(t_type_helpers, understood_simple_no) {
 }
 
 TEST(t_type_helpers, understood_simple_vector_yes) {
-    EXPECT_EQ(is_understood_type("vector<hi>", set<string>({"vector<hi>"})), true);
+    EXPECT_EQ(is_understood_type("vector<hi>", set<string>({"std::vector<hi>"})), true);
 }
 
 TEST(t_type_helpers, understood_simple_vector_no) {


### PR DESCRIPTION
There were two problems in the yaml creation that lead to certain object types not working when the codegen would build the injected query.

1. vector<> object without std::
2. vector<const ...> for non pointer objects

Both of these setups cause build time errors that lead to more advanced POs not working. The code in the PR adds the std:: when needed and removes the const when it is inside a vector and not a pointer.

The tests also needed to be edited to make sure that they were looking for the correct object. That is std::vector and not vector.

I have been able to get all of my funcadl code that I have been working on in the last month or so to work with the r25 library generated from these changes.

No CaloRings work!